### PR TITLE
Fixes Add a "buildName" optional parameter when building engine #92

### DIFF
--- a/src/Serval.Client/Client.g.cs
+++ b/src/Serval.Client/Client.g.cs
@@ -4290,6 +4290,9 @@ namespace Serval.Client
         [Newtonsoft.Json.JsonProperty("revision", Required = Newtonsoft.Json.Required.Always)]
         public int Revision { get; set; } = default!;
 
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? Name { get; set; } = default!;
+
         [Newtonsoft.Json.JsonProperty("engine", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
         public ResourceLink Engine { get; set; } = new ResourceLink();
@@ -4355,6 +4358,9 @@ namespace Serval.Client
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.18.2.0 (NJsonSchema v10.8.0.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class TranslationBuildConfig
     {
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? Name { get; set; } = default!;
+
         [Newtonsoft.Json.JsonProperty("pretranslate", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IList<PretranslateCorpusConfig>? Pretranslate { get; set; } = default!;
 

--- a/src/Serval.Translation/Contracts/TranslationBuildConfigDto.cs
+++ b/src/Serval.Translation/Contracts/TranslationBuildConfigDto.cs
@@ -2,5 +2,6 @@
 
 public class TranslationBuildConfigDto
 {
+    public string? Name { get; set; }
     public IList<PretranslateCorpusConfigDto>? Pretranslate { get; set; }
 }

--- a/src/Serval.Translation/Contracts/TranslationBuildDto.cs
+++ b/src/Serval.Translation/Contracts/TranslationBuildDto.cs
@@ -5,6 +5,7 @@ public class TranslationBuildDto
     public string Id { get; set; } = default!;
     public string Url { get; set; } = default!;
     public int Revision { get; set; }
+    public string? Name { get; set; }
     public ResourceLinkDto Engine { get; set; } = default!;
     public IList<PretranslateCorpusDto>? Pretranslate { get; set; }
     public int Step { get; set; }

--- a/src/Serval.Translation/Controllers/TranslationEnginesController.cs
+++ b/src/Serval.Translation/Controllers/TranslationEnginesController.cs
@@ -960,7 +960,7 @@ public class TranslationEnginesController : ServalControllerBase
 
     private static Build Map(Engine engine, TranslationBuildConfigDto source)
     {
-        var build = new Build { EngineRef = engine.Id };
+        var build = new Build { EngineRef = engine.Id, Name = source.Name };
         if (source.Pretranslate != null)
         {
             var pretranslateCorpora = new List<PretranslateCorpus>();
@@ -1003,6 +1003,7 @@ public class TranslationEnginesController : ServalControllerBase
             Id = source.Id,
             Url = _urlService.GetUrl("GetTranslationBuild", new { id = source.EngineRef, buildId = source.Id }),
             Revision = source.Revision,
+            Name = source.Name,
             Engine = new ResourceLinkDto
             {
                 Id = source.EngineRef,

--- a/src/Serval.Translation/Models/Build.cs
+++ b/src/Serval.Translation/Models/Build.cs
@@ -4,6 +4,7 @@ public class Build : IEntity
 {
     public string Id { get; set; } = default!;
     public int Revision { get; set; } = 1;
+    public string? Name { get; set; }
     public string EngineRef { get; set; } = default!;
     public List<PretranslateCorpus>? Pretranslate { get; set; }
     public int Step { get; set; }


### PR DESCRIPTION
For consistency, I chose to call it just "name" rather than "buildName".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/131)
<!-- Reviewable:end -->
