### PR TITLE
Build options is an arbitrary json object rather than a string

### DIFF
--- a/src/Serval.Client/Client.g.cs
+++ b/src/Serval.Client/Client.g.cs
@@ -1015,8 +1015,8 @@ namespace Serval.Client
         /// <br/>you may flag a subset of books for pretranslation by including their [abbreviations](https://github.com/sillsdev/libpalaso/blob/master/SIL.Scripture/Canon.cs)
         /// <br/>in the textIds parameter. If the engine does not support pretranslation, these fields have no effect.
         /// <br/>            
-        /// <br/>The `"options"` parameter of the build config provides the ability to pass build configuration parameters as a JSON string.
-        /// <br/>A typical use case would be to set `"options"` to `"{\"max_steps\":10}"` in order to configure the maximum
+        /// <br/>The `"options"` parameter of the build config provides the ability to pass build configuration parameters as a JSON object.
+        /// <br/>A typical use case would be to set `"options"` to `{"max_steps":10}` in order to configure the maximum
         /// <br/>number of training iterations in order to reduce turnaround time for testing purposes.
         /// </remarks>
         /// <param name="id">The translation engine id</param>
@@ -2918,8 +2918,8 @@ namespace Serval.Client
         /// <br/>you may flag a subset of books for pretranslation by including their [abbreviations](https://github.com/sillsdev/libpalaso/blob/master/SIL.Scripture/Canon.cs)
         /// <br/>in the textIds parameter. If the engine does not support pretranslation, these fields have no effect.
         /// <br/>            
-        /// <br/>The `"options"` parameter of the build config provides the ability to pass build configuration parameters as a JSON string.
-        /// <br/>A typical use case would be to set `"options"` to `"{\"max_steps\":10}"` in order to configure the maximum
+        /// <br/>The `"options"` parameter of the build config provides the ability to pass build configuration parameters as a JSON object.
+        /// <br/>A typical use case would be to set `"options"` to `{"max_steps":10}` in order to configure the maximum
         /// <br/>number of training iterations in order to reduce turnaround time for testing purposes.
         /// </remarks>
         /// <param name="id">The translation engine id</param>
@@ -4504,7 +4504,7 @@ namespace Serval.Client
         public System.Collections.Generic.IList<PretranslateCorpusConfig>? Pretranslate { get; set; } = default!;
 
         [Newtonsoft.Json.JsonProperty("options", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string? Options { get; set; } = default!;
+        public object? Options { get; set; } = default!;
 
     }
 

--- a/src/Serval.Client/Client.g.cs
+++ b/src/Serval.Client/Client.g.cs
@@ -4457,7 +4457,7 @@ namespace Serval.Client
         public System.DateTimeOffset? DateFinished { get; set; } = default!;
 
         [Newtonsoft.Json.JsonProperty("options", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string? Options { get; set; } = default!;
+        public object? Options { get; set; } = default!;
 
     }
 

--- a/src/Serval.Translation/Contracts/TranslationBuildConfigDto.cs
+++ b/src/Serval.Translation/Contracts/TranslationBuildConfigDto.cs
@@ -5,5 +5,5 @@ public class TranslationBuildConfigDto
     public string? Name { get; set; }
     public IList<PretranslateCorpusConfigDto>? Pretranslate { get; set; }
 
-    public string? Options { get; set; }
+    public object? Options { get; set; }
 }

--- a/src/Serval.Translation/Contracts/TranslationBuildConfigDto.cs
+++ b/src/Serval.Translation/Contracts/TranslationBuildConfigDto.cs
@@ -5,5 +5,10 @@ public class TranslationBuildConfigDto
     public string? Name { get; set; }
     public IList<PretranslateCorpusConfigDto>? Pretranslate { get; set; }
 
+    /// <example>
+    /// {
+    ///   "property" : "value"
+    /// }
+    /// </example>
     public object? Options { get; set; }
 }

--- a/src/Serval.Translation/Contracts/TranslationBuildDto.cs
+++ b/src/Serval.Translation/Contracts/TranslationBuildDto.cs
@@ -19,5 +19,5 @@ public class TranslationBuildDto
     /// </summary>
     public JobState State { get; set; }
     public DateTime? DateFinished { get; set; }
-    public string? Options { get; set; }
+    public object? Options { get; set; }
 }

--- a/src/Serval.Translation/Contracts/TranslationBuildDto.cs
+++ b/src/Serval.Translation/Contracts/TranslationBuildDto.cs
@@ -19,5 +19,11 @@ public class TranslationBuildDto
     /// </summary>
     public JobState State { get; set; }
     public DateTime? DateFinished { get; set; }
+
+    /// <example>
+    /// {
+    ///   "property" : "value"
+    /// }
+    /// </example>
     public object? Options { get; set; }
 }

--- a/src/Serval.Translation/Controllers/TranslationEnginesController.cs
+++ b/src/Serval.Translation/Controllers/TranslationEnginesController.cs
@@ -1070,7 +1070,7 @@ public class TranslationEnginesController : ServalControllerBase
             QueueDepth = source.QueueDepth,
             State = source.State,
             DateFinished = source.DateFinished,
-            Options = JsonSerializer.Serialize(source.Options)
+            Options = source.Options
         };
     }
 

--- a/src/Serval.Translation/Controllers/TranslationEnginesController.cs
+++ b/src/Serval.Translation/Controllers/TranslationEnginesController.cs
@@ -772,8 +772,8 @@ public class TranslationEnginesController : ServalControllerBase
     /// you may flag a subset of books for pretranslation by including their [abbreviations](https://github.com/sillsdev/libpalaso/blob/master/SIL.Scripture/Canon.cs)
     /// in the textIds parameter. If the engine does not support pretranslation, these fields have no effect.
     ///
-    /// The `"options"` parameter of the build config provides the ability to pass build configuration parameters as a JSON string.
-    /// A typical use case would be to set `"options"` to `"{\"max_steps\":10}"` in order to configure the maximum
+    /// The `"options"` parameter of the build config provides the ability to pass build configuration parameters as a JSON object.
+    /// A typical use case would be to set `"options"` to `{"max_steps":10}` in order to configure the maximum
     /// number of training iterations in order to reduce turnaround time for testing purposes.
     /// </remarks>
     /// <param name="id">The translation engine id</param>
@@ -1020,7 +1020,7 @@ public class TranslationEnginesController : ServalControllerBase
             var jsonSerializerOptions = new JsonSerializerOptions();
             jsonSerializerOptions.Converters.Add(new ObjectToInferredTypesConverter());
             build.Options = JsonSerializer.Deserialize<IDictionary<string, object>>(
-                source.Options ?? "{}",
+                source.Options?.ToString() ?? "{}",
                 jsonSerializerOptions
             );
         }


### PR DESCRIPTION
Fixes #180. I've verified that arbitrary JSON can be passed without error and parsed properly. It can also continue to be passed as a string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/183)
<!-- Reviewable:end -->
