### PR TITLE
Specifying max steps as 10 in build options was inadvertently removed

### DIFF
--- a/tests/Serval.E2ETests/ServalClientHelper.cs
+++ b/tests/Serval.E2ETests/ServalClientHelper.cs
@@ -29,7 +29,11 @@ public class ServalClientHelper
             $"Bearer {GetAuth0Authentication(env["authUrl"], audience, env["clientId"], env["clientSecret"]).Result}"
         );
         _prefix = prefix;
-        TranslationBuildConfig = new TranslationBuildConfig { Pretranslate = new List<PretranslateCorpusConfig>() };
+        TranslationBuildConfig = new TranslationBuildConfig
+        {
+            Pretranslate = new List<PretranslateCorpusConfig>(),
+            Options = "{\"max_steps\":10}"
+        };
     }
 
     public TranslationBuildConfig TranslationBuildConfig { get; set; }


### PR DESCRIPTION
This should solve some of the E2E testing timeout issues we've encountered. My mistake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/204)
<!-- Reviewable:end -->
