### PR TITLE
Fix spelling mistakes in the API documentation

### DIFF
--- a/src/Serval.Client/Client.g.cs
+++ b/src/Serval.Client/Client.g.cs
@@ -1365,10 +1365,10 @@ namespace Serval.Client
         /// <br/>* **isModelPersisted**: (optional) - see below
         /// <br/>### smt-transfer
         /// <br/>The Statistical Machine Translation Transfer Learning engine is primarily used for translation suggestions. Typical endpoints: translate, get-word-graph, train-segment
-        /// <br/>* **IsModelPersisted**: (default to true) All models are persistant and can be updated with train-segment.  False is not supported.
+        /// <br/>* **IsModelPersisted**: (default to true) All models are persistent and can be updated with train-segment.  False is not supported.
         /// <br/>### nmt
         /// <br/>The Neural Machine Translation engine is primarily used for pretranslations.  It is fine-tuned from Meta's NLLB-200. Valid IETF language tags provided to Serval will be converted to [NLLB-200 codes](https://github.com/facebookresearch/flores/tree/main/flores200#languages-in-flores-200).  See more about language tag resolution [here](https://github.com/sillsdev/serval/wiki/FLORES%E2%80%90200-Language-Code-Resolution-for-NMT-Engine).
-        /// <br/>* **IsModelPersisted**: (default to false) Whether the model can be downloaded by the client after it has been sucessfully built.
+        /// <br/>* **IsModelPersisted**: (default to false) Whether the model can be downloaded by the client after it has been successfully built.
         /// <br/>            
         /// <br/>If you use a language among NLLB's supported languages, Serval will utilize everything the NLLB-200 model already knows about that language when translating. If the language you are working with is not among NLLB's supported languages, the language code will have no effect.
         /// <br/>            
@@ -1666,7 +1666,7 @@ namespace Serval.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Let a link to download the NMT translation model of the last build that was sucessfully saved.
+        /// Let a link to download the NMT translation model of the last build that was successfully saved.
         /// </summary>
         /// <remarks>
         /// If a Nmt build was successful and IsModelPersisted is `true` for the engine,
@@ -1829,10 +1829,10 @@ namespace Serval.Client
         /// <br/>* **isModelPersisted**: (optional) - see below
         /// <br/>### smt-transfer
         /// <br/>The Statistical Machine Translation Transfer Learning engine is primarily used for translation suggestions. Typical endpoints: translate, get-word-graph, train-segment
-        /// <br/>* **IsModelPersisted**: (default to true) All models are persistant and can be updated with train-segment.  False is not supported.
+        /// <br/>* **IsModelPersisted**: (default to true) All models are persistent and can be updated with train-segment.  False is not supported.
         /// <br/>### nmt
         /// <br/>The Neural Machine Translation engine is primarily used for pretranslations.  It is fine-tuned from Meta's NLLB-200. Valid IETF language tags provided to Serval will be converted to [NLLB-200 codes](https://github.com/facebookresearch/flores/tree/main/flores200#languages-in-flores-200).  See more about language tag resolution [here](https://github.com/sillsdev/serval/wiki/FLORES%E2%80%90200-Language-Code-Resolution-for-NMT-Engine).
-        /// <br/>* **IsModelPersisted**: (default to false) Whether the model can be downloaded by the client after it has been sucessfully built.
+        /// <br/>* **IsModelPersisted**: (default to false) Whether the model can be downloaded by the client after it has been successfully built.
         /// <br/>            
         /// <br/>If you use a language among NLLB's supported languages, Serval will utilize everything the NLLB-200 model already knows about that language when translating. If the language you are working with is not among NLLB's supported languages, the language code will have no effect.
         /// <br/>            
@@ -4276,7 +4276,7 @@ namespace Serval.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Let a link to download the NMT translation model of the last build that was sucessfully saved.
+        /// Let a link to download the NMT translation model of the last build that was successfully saved.
         /// </summary>
         /// <remarks>
         /// If a Nmt build was successful and IsModelPersisted is `true` for the engine,
@@ -4517,14 +4517,14 @@ namespace Serval.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get infromation regarding a language for a given engine type
+        /// Get information regarding a language for a given engine type
         /// </summary>
         /// <remarks>
         /// This endpoint is to support Nmt models.  It specifies the ISO 639-3 code that the language maps to
         /// <br/>and whether it is supported in the NLLB 200 model without training.  This is useful for determining if a
         /// <br/>language is an appropriate candidate for a source language or if two languages can be translated between
         /// <br/>**Base Models available**
-        /// <br/>* **NLLB-200**: This is the only current base transaltion model available.
+        /// <br/>* **NLLB-200**: This is the only current base translation model available.
         /// <br/>  * The languages included in the base model are [here](https://github.com/facebookresearch/flores/blob/main/nllb_seed/README.md)
         /// <br/>without training.
         /// <br/>Response format:
@@ -4681,14 +4681,14 @@ namespace Serval.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get infromation regarding a language for a given engine type
+        /// Get information regarding a language for a given engine type
         /// </summary>
         /// <remarks>
         /// This endpoint is to support Nmt models.  It specifies the ISO 639-3 code that the language maps to
         /// <br/>and whether it is supported in the NLLB 200 model without training.  This is useful for determining if a
         /// <br/>language is an appropriate candidate for a source language or if two languages can be translated between
         /// <br/>**Base Models available**
-        /// <br/>* **NLLB-200**: This is the only current base transaltion model available.
+        /// <br/>* **NLLB-200**: This is the only current base translation model available.
         /// <br/>  * The languages included in the base model are [here](https://github.com/facebookresearch/flores/blob/main/nllb_seed/README.md)
         /// <br/>without training.
         /// <br/>Response format:

--- a/src/Serval.Translation/Controllers/TranslationEngineTypesController.cs
+++ b/src/Serval.Translation/Controllers/TranslationEngineTypesController.cs
@@ -41,14 +41,14 @@ public class TranslationEngineTypesController(IAuthorizationService authService,
     }
 
     /// <summary>
-    /// Get infromation regarding a language for a given engine type
+    /// Get information regarding a language for a given engine type
     /// </summary>
     /// <remarks>
     /// This endpoint is to support Nmt models.  It specifies the ISO 639-3 code that the language maps to
     /// and whether it is supported in the NLLB 200 model without training.  This is useful for determining if a
     /// language is an appropriate candidate for a source language or if two languages can be translated between
     /// **Base Models available**
-    /// * **NLLB-200**: This is the only current base transaltion model available.
+    /// * **NLLB-200**: This is the only current base translation model available.
     ///   * The languages included in the base model are [here](https://github.com/facebookresearch/flores/blob/main/nllb_seed/README.md)
     /// without training.
     /// Response format:

--- a/src/Serval.Translation/Controllers/TranslationEnginesController.cs
+++ b/src/Serval.Translation/Controllers/TranslationEnginesController.cs
@@ -79,10 +79,10 @@ public class TranslationEnginesController(
     /// * **isModelPersisted**: (optional) - see below
     /// ### smt-transfer
     /// The Statistical Machine Translation Transfer Learning engine is primarily used for translation suggestions. Typical endpoints: translate, get-word-graph, train-segment
-    /// * **IsModelPersisted**: (default to true) All models are persistant and can be updated with train-segment.  False is not supported.
+    /// * **IsModelPersisted**: (default to true) All models are persistent and can be updated with train-segment.  False is not supported.
     /// ### nmt
     /// The Neural Machine Translation engine is primarily used for pretranslations.  It is fine-tuned from Meta's NLLB-200. Valid IETF language tags provided to Serval will be converted to [NLLB-200 codes](https://github.com/facebookresearch/flores/tree/main/flores200#languages-in-flores-200).  See more about language tag resolution [here](https://github.com/sillsdev/serval/wiki/FLORES%E2%80%90200-Language-Code-Resolution-for-NMT-Engine).
-    /// * **IsModelPersisted**: (default to false) Whether the model can be downloaded by the client after it has been sucessfully built.
+    /// * **IsModelPersisted**: (default to false) Whether the model can be downloaded by the client after it has been successfully built.
     ///
     /// If you use a language among NLLB's supported languages, Serval will utilize everything the NLLB-200 model already knows about that language when translating. If the language you are working with is not among NLLB's supported languages, the language code will have no effect.
     ///
@@ -897,7 +897,7 @@ public class TranslationEnginesController(
     }
 
     /// <summary>
-    /// Let a link to download the NMT translation model of the last build that was sucessfully saved.
+    /// Let a link to download the NMT translation model of the last build that was successfully saved.
     /// </summary>
     /// <remarks>
     /// If a Nmt build was successful and IsModelPersisted is `true` for the engine,


### PR DESCRIPTION
* Fix spelling mistakes in the Serval API documentation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/313)
<!-- Reviewable:end -->
