### PR TITLE
#370 - control pretranslating existing text

### DIFF
--- a/src/Serval.Client/Client.g.cs
+++ b/src/Serval.Client/Client.g.cs
@@ -1625,14 +1625,21 @@ namespace Serval.Client
         /// <br/>segments in the the target book and returned. If the USFM book does not exist in the target corpus, then the
         /// <br/>pretranslated text will be inserted into an empty template created from the source USFM book and returned.
         /// <br/>Only pretranslations for the most recent successful build of the engine are returned.
-        /// <br/>Both scripture and non-scripture text is pretranslated according to [this wiki](https://github.com/sillsdev/serval/wiki/USFM-Parsing-and-Translation)
+        /// <br/>            
+        /// <br/>The text that populates the USFM structure can be controlled by the `textOrigin` parameter where with these options:
+        /// <br/>* `PreferExisting`: The existing and pretranslated texts are merged into the USFM, preferring existing text.  **This is the default**.
+        /// <br/>* `PreferPretranslated`: The existing and pretranslated texts are merged into the USFM, preferring pretranslated text.
+        /// <br/>* `OnlyExisting`: Return the existing target USFM file with no modifications (except updating the USFM id if needed)
+        /// <br/>* `OnlyPretranslated`: Only the pretranslated text is returned; all existing text in the target USFM is removed
+        /// <br/>Both scripture and non-scripture text in the USFM is parsed and grouped according to [this wiki](https://github.com/sillsdev/serval/wiki/USFM-Parsing-and-Translation)
         /// </remarks>
         /// <param name="id">The translation engine id</param>
         /// <param name="corpusId">The corpus id</param>
         /// <param name="textId">The text id</param>
+        /// <param name="textOrigin">The source[s] of the data to populate the USFM file with.</param>
         /// <returns>The book in USFM format</returns>
         /// <exception cref="ServalApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<string> GetPretranslatedUsfmAsync(string id, string corpusId, string textId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<string> GetPretranslatedUsfmAsync(string id, string corpusId, string textId, PretranslationUsfmTextOrigin? textOrigin = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -1648,18 +1655,18 @@ namespace Serval.Client
         /// Starts a build job for a translation engine.
         /// </summary>
         /// <remarks>
-        /// Specify the corpora or textIds to pretranslate.  Even when a corpus or textId
-        /// <br/>is selected for pretranslation, only "untranslated" text will be pretranslated:
-        /// <br/>that is, segments (lines of text) in the specified corpora or textId's that have
-        /// <br/>untranslated text but no translated text. If a corpus is a Paratext project,
-        /// <br/>you may flag a subset of books for pretranslation by including their [abbreviations](https://github.com/sillsdev/libpalaso/blob/master/SIL.Scripture/Canon.cs)
-        /// <br/>in the textIds parameter. If the engine does not support pretranslation, these fields have no effect.
-        /// <br/>            
-        /// <br/>Similarly, specify the corpora and textIds to train on. If no train_on field is provided, all corpora will be used.
-        /// <br/>Paratext projects can be filtered by book for training and pretranslating. This filtering follows the original versification.
-        /// <br/>To filter, use the 3 character code for the book of the Bible in the textID while building. See [here](https://github.com/sillsdev/serval/wiki/Versification-in-Serval) for more information.
+        /// Specify the corpora and textIds to train on. If no "trainOn" field is provided, all corpora will be used.
+        /// <br/>Paratext Projects, you may flag a subset of books for training by including their [abbreviations]
+        /// <br/>Paratext projects can be filtered by [book](https://github.com/sillsdev/libpalaso/blob/master/SIL.Scripture/Canon.cs) using the textId for training.
         /// <br/>Filters can also be supplied via scriptureRange parameter as ranges of biblical text. See [here](https://github.com/sillsdev/serval/wiki/Filtering-Paratext-Project-Data-with-a-Scripture-Range)
-        /// <br/>for more details.
+        /// <br/>All Paratext project filtering follows original versification. See [here](https://github.com/sillsdev/serval/wiki/Versification-in-Serval) for more information.
+        /// <br/>            
+        /// <br/>Specify the corpora or textIds to pretranslate.  When a corpus or textId is selected for pretranslation,
+        /// <br/>the following text will be pretranslated:
+        /// <br/>* Text segments that are in the source and not the target (untranslated)
+        /// <br/>* Text segments that are in the source and the target, but where that target segment is not trained on.
+        /// <br/>If the engine does not support pretranslation, these fields have no effect.
+        /// <br/>Pretranslating has the same filtering as training.
         /// <br/>            
         /// <br/>The `"options"` parameter of the build config provides the ability to pass build configuration parameters as a JSON object.
         /// <br/>See [nmt job settings documentation](https://github.com/sillsdev/serval/wiki/NMT-Build-Options) about configuring job parameters.
@@ -3586,14 +3593,21 @@ namespace Serval.Client
         /// <br/>segments in the the target book and returned. If the USFM book does not exist in the target corpus, then the
         /// <br/>pretranslated text will be inserted into an empty template created from the source USFM book and returned.
         /// <br/>Only pretranslations for the most recent successful build of the engine are returned.
-        /// <br/>Both scripture and non-scripture text is pretranslated according to [this wiki](https://github.com/sillsdev/serval/wiki/USFM-Parsing-and-Translation)
+        /// <br/>            
+        /// <br/>The text that populates the USFM structure can be controlled by the `textOrigin` parameter where with these options:
+        /// <br/>* `PreferExisting`: The existing and pretranslated texts are merged into the USFM, preferring existing text.  **This is the default**.
+        /// <br/>* `PreferPretranslated`: The existing and pretranslated texts are merged into the USFM, preferring pretranslated text.
+        /// <br/>* `OnlyExisting`: Return the existing target USFM file with no modifications (except updating the USFM id if needed)
+        /// <br/>* `OnlyPretranslated`: Only the pretranslated text is returned; all existing text in the target USFM is removed
+        /// <br/>Both scripture and non-scripture text in the USFM is parsed and grouped according to [this wiki](https://github.com/sillsdev/serval/wiki/USFM-Parsing-and-Translation)
         /// </remarks>
         /// <param name="id">The translation engine id</param>
         /// <param name="corpusId">The corpus id</param>
         /// <param name="textId">The text id</param>
+        /// <param name="textOrigin">The source[s] of the data to populate the USFM file with.</param>
         /// <returns>The book in USFM format</returns>
         /// <exception cref="ServalApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<string> GetPretranslatedUsfmAsync(string id, string corpusId, string textId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<string> GetPretranslatedUsfmAsync(string id, string corpusId, string textId, PretranslationUsfmTextOrigin? textOrigin = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (id == null)
                 throw new System.ArgumentNullException("id");
@@ -3623,6 +3637,12 @@ namespace Serval.Client
                     urlBuilder_.Append("/pretranslations/");
                     urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(textId, System.Globalization.CultureInfo.InvariantCulture)));
                     urlBuilder_.Append("/usfm");
+            urlBuilder_.Append('?');
+            if (textOrigin != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("text-origin")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(textOrigin, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+            }
+            urlBuilder_.Length--;
 
                     PrepareRequest(client_, request_, urlBuilder_);
 
@@ -3824,18 +3844,18 @@ namespace Serval.Client
         /// Starts a build job for a translation engine.
         /// </summary>
         /// <remarks>
-        /// Specify the corpora or textIds to pretranslate.  Even when a corpus or textId
-        /// <br/>is selected for pretranslation, only "untranslated" text will be pretranslated:
-        /// <br/>that is, segments (lines of text) in the specified corpora or textId's that have
-        /// <br/>untranslated text but no translated text. If a corpus is a Paratext project,
-        /// <br/>you may flag a subset of books for pretranslation by including their [abbreviations](https://github.com/sillsdev/libpalaso/blob/master/SIL.Scripture/Canon.cs)
-        /// <br/>in the textIds parameter. If the engine does not support pretranslation, these fields have no effect.
-        /// <br/>            
-        /// <br/>Similarly, specify the corpora and textIds to train on. If no train_on field is provided, all corpora will be used.
-        /// <br/>Paratext projects can be filtered by book for training and pretranslating. This filtering follows the original versification.
-        /// <br/>To filter, use the 3 character code for the book of the Bible in the textID while building. See [here](https://github.com/sillsdev/serval/wiki/Versification-in-Serval) for more information.
+        /// Specify the corpora and textIds to train on. If no "trainOn" field is provided, all corpora will be used.
+        /// <br/>Paratext Projects, you may flag a subset of books for training by including their [abbreviations]
+        /// <br/>Paratext projects can be filtered by [book](https://github.com/sillsdev/libpalaso/blob/master/SIL.Scripture/Canon.cs) using the textId for training.
         /// <br/>Filters can also be supplied via scriptureRange parameter as ranges of biblical text. See [here](https://github.com/sillsdev/serval/wiki/Filtering-Paratext-Project-Data-with-a-Scripture-Range)
-        /// <br/>for more details.
+        /// <br/>All Paratext project filtering follows original versification. See [here](https://github.com/sillsdev/serval/wiki/Versification-in-Serval) for more information.
+        /// <br/>            
+        /// <br/>Specify the corpora or textIds to pretranslate.  When a corpus or textId is selected for pretranslation,
+        /// <br/>the following text will be pretranslated:
+        /// <br/>* Text segments that are in the source and not the target (untranslated)
+        /// <br/>* Text segments that are in the source and the target, but where that target segment is not trained on.
+        /// <br/>If the engine does not support pretranslation, these fields have no effect.
+        /// <br/>Pretranslating has the same filtering as training.
         /// <br/>            
         /// <br/>The `"options"` parameter of the build config provides the ability to pass build configuration parameters as a JSON object.
         /// <br/>See [nmt job settings documentation](https://github.com/sillsdev/serval/wiki/NMT-Build-Options) about configuring job parameters.
@@ -5962,6 +5982,24 @@ namespace Serval.Client
         [Newtonsoft.Json.JsonProperty("translation", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         public string Translation { get; set; } = default!;
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.0.2.0 (NJsonSchema v11.0.0.0 (Newtonsoft.Json v13.0.0.0))")]
+    public enum PretranslationUsfmTextOrigin
+    {
+
+        [System.Runtime.Serialization.EnumMember(Value = @"PreferExisting")]
+        PreferExisting = 0,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"PreferPretranslated")]
+        PreferPretranslated = 1,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"OnlyExisting")]
+        OnlyExisting = 2,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"OnlyPretranslated")]
+        OnlyPretranslated = 3,
 
     }
 

--- a/src/Serval.Shared/Serval.Shared.csproj
+++ b/src/Serval.Shared/Serval.Shared.csproj
@@ -19,7 +19,7 @@
 		<PackageReference Include="Grpc.Core.Api" Version="2.52.0" />
 		<PackageReference Include="Grpc.HealthCheck" Version="2.52.0" />
 		<PackageReference Include="Grpc.Net.ClientFactory" Version="2.52.0" />
-		<PackageReference Include="SIL.Machine" Version="3.1.0" Condition="!Exists('..\..\..\machine\src\SIL.Machine\SIL.Machine.csproj')" />
+		<PackageReference Include="SIL.Machine" Version="3.1.1" Condition="!Exists('..\..\..\machine\src\SIL.Machine\SIL.Machine.csproj')" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Serval.Translation/Contracts/PretranslationUsfmTextOrigin.cs
+++ b/src/Serval.Translation/Contracts/PretranslationUsfmTextOrigin.cs
@@ -1,0 +1,9 @@
+﻿namespace Serval.Translation.Contracts;
+
+public enum PretranslationUsfmTextOrigin
+{
+    PreferExisting,
+    PreferPretranslated,
+    OnlyExisting,
+    OnlyPretranslated
+}

--- a/src/Serval.Translation/Services/IPretranslationService.cs
+++ b/src/Serval.Translation/Services/IPretranslationService.cs
@@ -15,6 +15,7 @@ public interface IPretranslationService
         int modelRevision,
         string corpusId,
         string textId,
+        PretranslationUsfmTextOrigin textOrigin,
         CancellationToken cancellationToken = default
     );
 }

--- a/tests/Serval.Translation.Tests/Services/EngineServiceTests.cs
+++ b/tests/Serval.Translation.Tests/Services/EngineServiceTests.cs
@@ -342,7 +342,7 @@ public class EngineServiceTests
             {
                 sources[i] = new TranslationSources();
                 if (!isUnknown)
-                    sources[i].Values.Add(TranslationSource.Primary);
+                    sources[i].Values.Add(V1.TranslationSource.Primary);
             }
             return sources;
         }

--- a/tests/Serval.Translation.Tests/Usings.cs
+++ b/tests/Serval.Translation.Tests/Usings.cs
@@ -9,6 +9,7 @@ global using NUnit.Framework;
 global using Serval.Shared.Configuration;
 global using Serval.Shared.Services;
 global using Serval.Shared.Utils;
+global using Serval.Translation.Contracts;
 global using Serval.Translation.Models;
 global using SIL.DataAccess;
 global using SIL.Machine.Corpora;


### PR DESCRIPTION
I didn't need to add another parameter for pretranslating stuff that is not being trained on.  It seemed obvious (to me) that if a person is actively choosing not to train a specific verse, and asks for it pretranslated, we should just do what they want (credit to Damien for the idea).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/371)
<!-- Reviewable:end -->
