### PR TITLE
Update to Machine 3.2.0

### DIFF
--- a/src/Serval.Shared/Serval.Shared.csproj
+++ b/src/Serval.Shared/Serval.Shared.csproj
@@ -19,7 +19,7 @@
 		<PackageReference Include="Grpc.Core.Api" Version="2.52.0" />
 		<PackageReference Include="Grpc.HealthCheck" Version="2.52.0" />
 		<PackageReference Include="Grpc.Net.ClientFactory" Version="2.52.0" />
-		<PackageReference Include="SIL.Machine" Version="3.1.3" Condition="!Exists('..\..\..\machine\src\SIL.Machine\SIL.Machine.csproj')" />
+		<PackageReference Include="SIL.Machine" Version="3.2.0" Condition="!Exists('..\..\..\machine\src\SIL.Machine\SIL.Machine.csproj')" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Serval.Translation.Tests/Services/PretranslationServiceTests.cs
+++ b/tests/Serval.Translation.Tests/Services/PretranslationServiceTests.cs
@@ -12,7 +12,7 @@ public class PretranslationServiceTests
     {
         TestEnvironment env = new();
         string usfm = await env.Service.GetUsfmAsync("engine1", 1, "corpus1", "MAT", textOrigin: textOrigin);
-        Assert.That(usfm.Replace("\r\n", "\n"), Is.EqualTo(TestEnvironment.GetUsfm(returnUsfmType, id: "MAT - TRG")));
+        Assert.That(usfm.Replace("\r\n", "\n"), Is.EqualTo(TestEnvironment.GetUsfm(returnUsfmType)));
     }
 
     [Test]
@@ -25,7 +25,7 @@ public class PretranslationServiceTests
         TestEnvironment env = new();
         env.AddMatthewToTarget();
         string usfm = await env.Service.GetUsfmAsync("engine1", 1, "corpus1", "MAT", textOrigin: textOrigin);
-        Assert.That(usfm.Replace("\r\n", "\n"), Is.EqualTo(TestEnvironment.GetUsfm(returnUsfmType, id: "MAT - TRG")));
+        Assert.That(usfm.Replace("\r\n", "\n"), Is.EqualTo(TestEnvironment.GetUsfm(returnUsfmType)));
     }
 
     private class TestEnvironment
@@ -227,7 +227,7 @@ public class PretranslationServiceTests
 
         public static string GetUsfm(string type, string book = "MAT", string id = "MAT - TRG")
         {
-            return type switch
+            string usfm = type switch
             {
                 "OnlyPretranslated" => CreatePretranslationsOnly(id),
                 "PreferPretranslated" => CreatePreferPretranslations(book, id),
@@ -236,6 +236,7 @@ public class PretranslationServiceTests
                 "Blank" => CreateBlank(id),
                 _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
             };
+            return usfm.Replace("\r\n", "\n");
         }
     }
 }


### PR DESCRIPTION
- use relaxed Scripture references when inserting pretranslations into a target book

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/402)
<!-- Reviewable:end -->
