### PR TITLE
Remove timeout on MessageOutboxDeliveryService

### DIFF
--- a/docker-compose.withatlas.yml
+++ b/docker-compose.withatlas.yml
@@ -14,8 +14,8 @@ services:
       - ASPNETCORE_Kestrel__Endpoints__Http__Url=http://*:80
       - ASPNETCORE_Kestrel__Endpoints__Http2__Url=http://*:81
       - ASPNETCORE_Kestrel__Endpoints__Http2__Protocols=Http2
-      - ASPNETCORE_ConnectionStrings__Hangfire=${MONGO_CONNECTION_STRING:?connection string needed}/${MONGO_CONNECTION_PREFIX:?mongo prefix needed}serval_jobs
-      - ASPNETCORE_ConnectionStrings__Mongo=${MONGO_CONNECTION_STRING}/${MONGO_CONNECTION_PREFIX}serval
+      - ASPNETCORE_ConnectionStrings__Hangfire=${MONGO_CONNECTION_STRING:?connection string needed}/${MONGO_CONNECTION_PREFIX:?mongo prefix needed}serval_jobs${MONGO_EXTENSIONS}
+      - ASPNETCORE_ConnectionStrings__Mongo=${MONGO_CONNECTION_STRING}/${MONGO_CONNECTION_PREFIX}serval${MONGO_EXTENSIONS}
       - ASPNETCORE_Translation__Engines__0__Type=Echo
       - ASPNETCORE_Translation__Engines__0__Address=http://echo
       - ASPNETCORE_Translation__Engines__1__Type=SmtTransfer
@@ -74,22 +74,24 @@ services:
     hostname: machine-engine
     container_name: machine-engine-cntr
     build:
-      context: ${MACHINE_TESTING_DIR:-../machine}
-      dockerfile: ../machine/dockerfile.development
+      context: .
+      dockerfile: dockerfile.development
 
     environment:
       - ASPNETCORE_ENVIRONMENT=Staging
       - ASPNETCORE_Kestrel__Endpoints__Https__Url=http://*:80
       - ASPNETCORE_Kestrel__EndpointDefaults__Protocols=Http2
-      - ASPNETCORE_ConnectionStrings__Hangfire=${MONGO_CONNECTION_STRING}/${MONGO_CONNECTION_PREFIX}machine_jobs
-      - ASPNETCORE_ConnectionStrings__Mongo=${MONGO_CONNECTION_STRING}/${MONGO_CONNECTION_PREFIX}machine
+      - ASPNETCORE_ConnectionStrings__Hangfire=${MONGO_CONNECTION_STRING}/${MONGO_CONNECTION_PREFIX}machine_jobs${MONGO_EXTENSIONS}
+      - ASPNETCORE_ConnectionStrings__Mongo=${MONGO_CONNECTION_STRING}/${MONGO_CONNECTION_PREFIX}machine${MONGO_EXTENSIONS}
       - ASPNETCORE_ConnectionStrings__Serval=http://serval-api:81
       - ClearML__ApiServer=https://api.sil.hosted.allegro.ai
-      - ClearML__Queue=lambert_24gb
-      - ClearML__DockerImage=${MACHINE_PY_IMAGE:-ghcr.io/sillsdev/machine.py:latest}
       - ClearML__Project=docker-compose
       - "ClearML__AccessKey=${ClearML_AccessKey:?access key needed}"
       - "ClearML__SecretKey=${ClearML_SecretKey:?secret key needed}"
+      - BuildJob__ClearML__0__Queue=lambert_24gb
+      - BuildJob__ClearML__0__DockerImage=${MACHINE_PY_IMAGE:-ghcr.io/sillsdev/machine.py:latest}
+      - BuildJob__ClearML__1__Queue=lambert_24gb.cpu_only
+      - BuildJob__ClearML__1__DockerImage=${MACHINE_PY_CPU_IMAGE:-ghcr.io/sillsdev/machine.py:latest.cpu_only}
       - SharedFile__Uri=s3://aqua-ml-data/docker-compose/
       - "SharedFile__S3AccessKeyId=${AWS_ACCESS_KEY_ID:?access key needed}"
       - "SharedFile__S3SecretAccessKey=${AWS_SECRET_ACCESS_KEY:?secret key needed}"
@@ -100,11 +102,11 @@ services:
     depends_on:
       - serval-api
     volumes:
-      - ${MACHINE_TESTING_DIR:-../machine}:/app:ro
+      - .:/app:ro
       - ~/.nuget/packages:/root/.nuget/packages:ro
       - /var/lib/machine:/var/lib/machine
       - /var/lib/serval:/var/lib/serval
-    working_dir: '/app/src/SIL.Machine.Serval.EngineServer'
+    working_dir: '/app/src/Machine/src/Serval.Machine.EngineServer'
     entrypoint:
       - dotnet
       - run
@@ -117,21 +119,23 @@ services:
     hostname: machine-job-server
     container_name: machine-job-cntr
     build:
-      context: ${MACHINE_TESTING_DIR:-../machine}
-      dockerfile: ../machine/dockerfile.development
+      context: .
+      dockerfile: dockerfile.development
     environment:
       - ASPNETCORE_ENVIRONMENT=Staging
-      - ASPNETCORE_ConnectionStrings__Hangfire=${MONGO_CONNECTION_STRING}/${MONGO_CONNECTION_PREFIX}machine_jobs
-      - ASPNETCORE_ConnectionStrings__Mongo=${MONGO_CONNECTION_STRING}/${MONGO_CONNECTION_PREFIX}machine
+      - ASPNETCORE_ConnectionStrings__Hangfire=${MONGO_CONNECTION_STRING}/${MONGO_CONNECTION_PREFIX}machine_jobs${MONGO_EXTENSIONS}
+      - ASPNETCORE_ConnectionStrings__Mongo=${MONGO_CONNECTION_STRING}/${MONGO_CONNECTION_PREFIX}machine${MONGO_EXTENSIONS}
       - ASPNETCORE_ConnectionStrings__Serval=http://serval-api:81
       - ASPNETCORE_Kestrel__Endpoints__Http__Url=http://*:80
       - ASPNETCORE_Kestrel__EndpointDefaults__Protocols=Http2
       - ClearML__ApiServer=https://api.sil.hosted.allegro.ai
-      - ClearML__Queue=lambert_24gb
-      - ClearML__DockerImage=${MACHINE_PY_IMAGE:-ghcr.io/sillsdev/machine.py:latest}
       - ClearML__Project=docker-compose
       - "ClearML__AccessKey=${ClearML_AccessKey:?access key needed}"
       - "ClearML__SecretKey=${ClearML_SecretKey:?secret key needed}"
+      - BuildJob__ClearML__0__Queue=lambert_24gb
+      - BuildJob__ClearML__0__DockerImage=${MACHINE_PY_IMAGE:-ghcr.io/sillsdev/machine.py:latest}
+      - BuildJob__ClearML__1__Queue=lambert_24gb.cpu_only
+      - BuildJob__ClearML__1__DockerImage=${MACHINE_PY_CPU_IMAGE:-ghcr.io/sillsdev/machine.py:latest.cpu_only}
       - SharedFile__Uri=s3://aqua-ml-data/docker-compose/
       - "SharedFile__S3AccessKeyId=${AWS_ACCESS_KEY_ID:?access key needed}"
       - "SharedFile__S3SecretAccessKey=${AWS_SECRET_ACCESS_KEY:?secret key needed}"
@@ -143,11 +147,11 @@ services:
       - machine-engine
       - serval-api
     volumes:
-      - ${MACHINE_TESTING_DIR:-../machine}:/app:ro
+      - .:/app:ro
       - ~/.nuget/packages:/root/.nuget/packages:ro
       - /var/lib/machine:/var/lib/machine
       - /var/lib/serval:/var/lib/serval
-    working_dir: '/app/src/SIL.Machine.Serval.JobServer'
+    working_dir: '/app/src/Machine/src/Serval.Machine.JobServer'
     entrypoint:
       - dotnet
       - run

--- a/src/Machine/src/Serval.Machine.Shared/Configuration/IMachineBuilderExtensions.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Configuration/IMachineBuilderExtensions.cs
@@ -258,10 +258,12 @@ public static class IMachineBuilderExtensions
                     {
                         await c.Indexes.CreateOrUpdateAsync(
                             new CreateIndexModel<TranslationEngine>(
-                                Builders<TranslationEngine>
-                                    .IndexKeys.Ascending(e => e.EngineId)
-                                    .Ascending("currentBuild._id")
-                                    .Ascending(e => e.CurrentBuild!.BuildJobRunner)
+                                Builders<TranslationEngine>.IndexKeys.Ascending(e => e.EngineId)
+                            )
+                        );
+                        await c.Indexes.CreateOrUpdateAsync(
+                            new CreateIndexModel<TranslationEngine>(
+                                Builders<TranslationEngine>.IndexKeys.Ascending(e => e.CurrentBuild!.BuildJobRunner)
                             )
                         );
                     }

--- a/src/Machine/src/Serval.Machine.Shared/Configuration/IMachineBuilderExtensions.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Configuration/IMachineBuilderExtensions.cs
@@ -261,11 +261,7 @@ public static class IMachineBuilderExtensions
                                 Builders<TranslationEngine>
                                     .IndexKeys.Ascending(e => e.EngineId)
                                     .Ascending("currentBuild._id")
-                            )
-                        );
-                        await c.Indexes.CreateOrUpdateAsync(
-                            new CreateIndexModel<TranslationEngine>(
-                                Builders<TranslationEngine>.IndexKeys.Ascending(e => e.CurrentBuild!.BuildJobRunner)
+                                    .Ascending(e => e.CurrentBuild!.BuildJobRunner)
                             )
                         );
                     }

--- a/src/Machine/src/Serval.Machine.Shared/Services/MessageOutboxDeliveryService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/MessageOutboxDeliveryService.cs
@@ -8,8 +8,6 @@ public class MessageOutboxDeliveryService(
     ILogger<MessageOutboxDeliveryService> logger
 ) : BackgroundService
 {
-    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
-
     private readonly IServiceProvider _services = services;
     private readonly Dictionary<string, IOutboxMessageHandler> _outboxMessageHandlers =
         outboxMessageHandlers.ToDictionary(o => o.OutboxId);
@@ -25,7 +23,7 @@ public class MessageOutboxDeliveryService(
         using ISubscription<OutboxMessage> subscription = await messages.SubscribeAsync(e => true, stoppingToken);
         while (true)
         {
-            await subscription.WaitForChangeAsync(timeout: Timeout, cancellationToken: stoppingToken);
+            await subscription.WaitForChangeAsync(cancellationToken: stoppingToken);
             if (stoppingToken.IsCancellationRequested)
                 break;
             await ProcessMessagesAsync(messages, stoppingToken);

--- a/src/Serval/src/Serval.Translation/Configuration/IMongoDataAccessConfiguratorExtensions.cs
+++ b/src/Serval/src/Serval.Translation/Configuration/IMongoDataAccessConfiguratorExtensions.cs
@@ -13,10 +13,9 @@ public static class IMongoDataAccessConfiguratorExtensions
             init: async c =>
             {
                 await c.Indexes.CreateOrUpdateAsync(
-                    new CreateIndexModel<Engine>(Builders<Engine>.IndexKeys.Ascending(e => e.Owner))
-                );
-                await c.Indexes.CreateOrUpdateAsync(
-                    new CreateIndexModel<Engine>(Builders<Engine>.IndexKeys.Ascending("corpora._id"))
+                    new CreateIndexModel<Engine>(
+                        Builders<Engine>.IndexKeys.Ascending(e => e.Owner).Ascending("corpora._id")
+                    )
                 );
             }
         );
@@ -33,21 +32,12 @@ public static class IMongoDataAccessConfiguratorExtensions
             {
                 await c.Indexes.CreateOrUpdateAsync(
                     new CreateIndexModel<Pretranslation>(
-                        Builders<Pretranslation>.IndexKeys.Ascending(pt => pt.EngineRef)
+                        Builders<Pretranslation>
+                            .IndexKeys.Ascending(pt => pt.EngineRef)
+                            .Ascending(pt => pt.ModelRevision)
+                            .Ascending(pt => pt.CorpusRef)
+                            .Ascending(pt => pt.TextId)
                     )
-                );
-                await c.Indexes.CreateOrUpdateAsync(
-                    new CreateIndexModel<Pretranslation>(
-                        Builders<Pretranslation>.IndexKeys.Ascending(pt => pt.ModelRevision)
-                    )
-                );
-                await c.Indexes.CreateOrUpdateAsync(
-                    new CreateIndexModel<Pretranslation>(
-                        Builders<Pretranslation>.IndexKeys.Ascending(pt => pt.CorpusRef)
-                    )
-                );
-                await c.Indexes.CreateOrUpdateAsync(
-                    new CreateIndexModel<Pretranslation>(Builders<Pretranslation>.IndexKeys.Ascending(pt => pt.TextId))
                 );
             }
         );

--- a/src/Serval/src/Serval.Translation/Configuration/IMongoDataAccessConfiguratorExtensions.cs
+++ b/src/Serval/src/Serval.Translation/Configuration/IMongoDataAccessConfiguratorExtensions.cs
@@ -45,6 +45,13 @@ public static class IMongoDataAccessConfiguratorExtensions
                     new CreateIndexModel<Pretranslation>(
                         Builders<Pretranslation>
                             .IndexKeys.Ascending(pt => pt.EngineRef)
+                            .Ascending(pt => pt.ModelRevision)
+                    )
+                );
+                await c.Indexes.CreateOrUpdateAsync(
+                    new CreateIndexModel<Pretranslation>(
+                        Builders<Pretranslation>
+                            .IndexKeys.Ascending(pt => pt.EngineRef)
                             .Ascending(pt => pt.CorpusRef)
                             .Ascending(pt => pt.ModelRevision)
                             .Ascending(pt => pt.TextId)

--- a/src/Serval/src/Serval.Translation/Configuration/IMongoDataAccessConfiguratorExtensions.cs
+++ b/src/Serval/src/Serval.Translation/Configuration/IMongoDataAccessConfiguratorExtensions.cs
@@ -13,9 +13,7 @@ public static class IMongoDataAccessConfiguratorExtensions
             init: async c =>
             {
                 await c.Indexes.CreateOrUpdateAsync(
-                    new CreateIndexModel<Engine>(
-                        Builders<Engine>.IndexKeys.Ascending(e => e.Owner).Ascending("corpora._id")
-                    )
+                    new CreateIndexModel<Engine>(Builders<Engine>.IndexKeys.Ascending(e => e.Owner))
                 );
             }
         );
@@ -32,10 +30,23 @@ public static class IMongoDataAccessConfiguratorExtensions
             {
                 await c.Indexes.CreateOrUpdateAsync(
                     new CreateIndexModel<Pretranslation>(
+                        Builders<Pretranslation>.IndexKeys.Ascending(pt => pt.ModelRevision)
+                    )
+                );
+                await c.Indexes.CreateOrUpdateAsync(
+                    new CreateIndexModel<Pretranslation>(
+                        Builders<Pretranslation>.IndexKeys.Ascending(pt => pt.CorpusRef)
+                    )
+                );
+                await c.Indexes.CreateOrUpdateAsync(
+                    new CreateIndexModel<Pretranslation>(Builders<Pretranslation>.IndexKeys.Ascending(pt => pt.TextId))
+                );
+                await c.Indexes.CreateOrUpdateAsync(
+                    new CreateIndexModel<Pretranslation>(
                         Builders<Pretranslation>
                             .IndexKeys.Ascending(pt => pt.EngineRef)
-                            .Ascending(pt => pt.ModelRevision)
                             .Ascending(pt => pt.CorpusRef)
+                            .Ascending(pt => pt.ModelRevision)
                             .Ascending(pt => pt.TextId)
                     )
                 );

--- a/src/Serval/src/Serval.Webhooks/Configuration/IMongoDataAccessConfiguratorExtensions.cs
+++ b/src/Serval/src/Serval.Webhooks/Configuration/IMongoDataAccessConfiguratorExtensions.cs
@@ -11,9 +11,7 @@ public static class IMongoDataAccessConfiguratorExtensions
             init: async c =>
             {
                 await c.Indexes.CreateOrUpdateAsync(
-                    new CreateIndexModel<Webhook>(
-                        Builders<Webhook>.IndexKeys.Ascending(h => h.Owner).Ascending(h => h.Events)
-                    )
+                    new CreateIndexModel<Webhook>(Builders<Webhook>.IndexKeys.Ascending(h => h.Events))
                 );
             }
         );

--- a/src/Serval/src/Serval.Webhooks/Configuration/IMongoDataAccessConfiguratorExtensions.cs
+++ b/src/Serval/src/Serval.Webhooks/Configuration/IMongoDataAccessConfiguratorExtensions.cs
@@ -11,10 +11,9 @@ public static class IMongoDataAccessConfiguratorExtensions
             init: async c =>
             {
                 await c.Indexes.CreateOrUpdateAsync(
-                    new CreateIndexModel<Webhook>(Builders<Webhook>.IndexKeys.Ascending(h => h.Owner))
-                );
-                await c.Indexes.CreateOrUpdateAsync(
-                    new CreateIndexModel<Webhook>(Builders<Webhook>.IndexKeys.Ascending(h => h.Events))
+                    new CreateIndexModel<Webhook>(
+                        Builders<Webhook>.IndexKeys.Ascending(h => h.Owner).Ascending(h => h.Events)
+                    )
                 );
             }
         );


### PR DESCRIPTION
Fixes #422 

I've gone ahead and added the recommended index on pretranslations which should speed up queries there significantly, but ultimately, it wasn't the queries on pretranslations that were taxing mongo and causing it to send alerts. 

Rather, it has to do with a bug in the `MessageOutboxDeliveryService`'s subscription. A timeout of 10 seconds is used when waiting for a new message to appear. However, when looping back to wait again, it's looking for changes from the same time onward since the timestamp which it uses as a placeholder only updates when there's been a change (i.e., not when it's timed out). For now, I've simply removed the timeout which fits with usage elsewhere. Now it should wait until there's been a change without rerunning the changeStream command. In recent versions of Mongo, it's also possible to resume changeStreams. It may be better (if we have situations in which we want a timeout but will also re-wait for changes) to use the resumeToken strategy to resume rather than restart.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/437)
<!-- Reviewable:end -->
