### PR TITLE
Add better ClearML parse logging info

### DIFF
--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/ClearMLServiceTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/ClearMLServiceTests.cs
@@ -26,8 +26,9 @@ public class ClearMLServiceTests
         authService.GetAuthTokenAsync().Returns(Task.FromResult("accessToken"));
         var env = new HostingEnvironment { EnvironmentName = Environments.Development };
         var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        var logger = Substitute.For<ILogger<ClearMLService>>();
         httpClientFactory.CreateClient("ClearML").Returns(httpClient);
-        var service = new ClearMLService(httpClientFactory, options, authService, env);
+        var service = new ClearMLService(httpClientFactory, options, authService, env, logger);
 
         string script =
             "from machine.jobs.build_nmt_engine import run\n"


### PR DESCRIPTION
Related to https://github.com/sillsdev/serval/issues/462.  Couldn't find the root issue, but this should hopefully lead to better logging of the errors we are getting from ClearML to see what we are actually getting back.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/463)
<!-- Reviewable:end -->
