### PR TITLE
Prestranslation versification mismatch

### DIFF
--- a/src/Machine/src/Serval.Machine.Shared/Services/PreprocessBuildJob.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/PreprocessBuildJob.cs
@@ -400,7 +400,7 @@ public class PreprocessBuildJob : HangfireBuildJob<IReadOnlyList<Corpus>>
         {
             if (!row.IsTargetRangeStart && row.IsTargetInRange)
             {
-                refs.AddRange(row.Refs);
+                refs.AddRange(row.TargetRefs);
                 if (row.SourceText.Length > 0)
                 {
                     if (srcSegBuffer.Length > 0)
@@ -422,7 +422,7 @@ public class PreprocessBuildJob : HangfireBuildJob<IReadOnlyList<Corpus>>
                 }
 
                 textId = row.TextId;
-                refs.AddRange(row.Refs);
+                refs.AddRange(row.TargetRefs);
                 srcSegBuffer.Append(row.SourceText);
                 trgSegBuffer.Append(row.TargetText);
                 rowCount++;

--- a/src/Serval/src/Serval.Translation/Services/PretranslationService.cs
+++ b/src/Serval/src/Serval.Translation/Services/PretranslationService.cs
@@ -62,12 +62,7 @@ public class PretranslationService(
             .Select(p =>
                 (
                     Refs: (IReadOnlyList<ScriptureRef>)
-                        p.Refs.Select(r =>
-                            ScriptureRef
-                                .Parse(r, sourceSettings.Versification)
-                                .ChangeVersification(targetSettings.Versification)
-                        )
-                            .ToArray(),
+                        p.Refs.Select(r => ScriptureRef.Parse(r, sourceSettings.Versification)).ToArray(),
                     p.Translation
                 )
             )
@@ -79,7 +74,11 @@ public class PretranslationService(
             // the pretranslations are generated from the source book and inserted into the target book
             // use relaxed references since the USFM structure may not be the same
             pretranslations = pretranslations.Select(p =>
-                ((IReadOnlyList<ScriptureRef>)p.Refs.Select(r => r.ToRelaxed()).ToArray(), p.Translation)
+                (
+                    (IReadOnlyList<ScriptureRef>)
+                        p.Refs.Select(r => r.ChangeVersification(targetSettings.Versification).ToRelaxed()).ToArray(),
+                    p.Translation
+                )
             );
             using Shared.Services.ZipParatextProjectTextUpdater updater =
                 _scriptureDataFileService.GetZipParatextProjectTextUpdater(targetFile.Filename);

--- a/src/Serval/src/Serval.Translation/Services/PretranslationService.cs
+++ b/src/Serval/src/Serval.Translation/Services/PretranslationService.cs
@@ -56,30 +56,25 @@ public class PretranslationService(
             targetFile.Filename
         );
 
-        IEnumerable<(IReadOnlyList<ScriptureRef> Refs, string Translation)> pretranslations = (
+        IEnumerable<(IReadOnlyList<string> Refs, string Translation)> rawPretranslations = (
             await GetAllAsync(engineId, modelRevision, corpusId, textId, cancellationToken)
-        )
-            .Select(p =>
-                (
-                    Refs: (IReadOnlyList<ScriptureRef>)
-                        p.Refs.Select(r => ScriptureRef.Parse(r, sourceSettings.Versification)).ToArray(),
-                    p.Translation
-                )
-            )
-            .OrderBy(p => p.Refs[0]);
+        ).Select(p => (p.Refs, p.Translation));
 
         // Update the target book if it exists
         if (template is PretranslationUsfmTemplate.Auto or PretranslationUsfmTemplate.Target)
         {
             // the pretranslations are generated from the source book and inserted into the target book
             // use relaxed references since the USFM structure may not be the same
-            pretranslations = pretranslations.Select(p =>
-                (
-                    (IReadOnlyList<ScriptureRef>)
-                        p.Refs.Select(r => r.ChangeVersification(targetSettings.Versification).ToRelaxed()).ToArray(),
-                    p.Translation
+            IEnumerable<(IReadOnlyList<ScriptureRef> Refs, string Translation)> pretranslations = rawPretranslations
+                .Select(p =>
+                    (
+                        (IReadOnlyList<ScriptureRef>)
+                            p.Refs.Select(r => ScriptureRef.Parse(r, targetSettings.Versification).ToRelaxed())
+                                .ToArray(),
+                        p.Translation
+                    )
                 )
-            );
+                .OrderBy(p => p.Item1[0]);
             using Shared.Services.ZipParatextProjectTextUpdater updater =
                 _scriptureDataFileService.GetZipParatextProjectTextUpdater(targetFile.Filename);
             string usfm = "";
@@ -133,6 +128,15 @@ public class PretranslationService(
 
         if (template is PretranslationUsfmTemplate.Auto or PretranslationUsfmTemplate.Source)
         {
+            IEnumerable<(IReadOnlyList<ScriptureRef> Refs, string Translation)> pretranslations = rawPretranslations
+                .Select(p =>
+                    (
+                        (IReadOnlyList<ScriptureRef>)
+                            p.Refs.Select(r => ScriptureRef.Parse(r, sourceSettings.Versification)).ToArray(),
+                        p.Translation
+                    )
+                )
+                .OrderBy(p => p.Item1[0]);
             using Shared.Services.ZipParatextProjectTextUpdater updater =
                 _scriptureDataFileService.GetZipParatextProjectTextUpdater(sourceFile.Filename);
 

--- a/src/Serval/src/Serval.Translation/Services/PretranslationService.cs
+++ b/src/Serval/src/Serval.Translation/Services/PretranslationService.cs
@@ -62,7 +62,12 @@ public class PretranslationService(
             .Select(p =>
                 (
                     Refs: (IReadOnlyList<ScriptureRef>)
-                        p.Refs.Select(r => ScriptureRef.Parse(r, targetSettings.Versification)).ToArray(),
+                        p.Refs.Select(r =>
+                            ScriptureRef
+                                .Parse(r, sourceSettings.Versification)
+                                .ChangeVersification(targetSettings.Versification)
+                        )
+                            .ToArray(),
                     p.Translation
                 )
             )


### PR DESCRIPTION
Partial fix for https://github.com/sillsdev/serval/issues/442

This solution has been verified by a manual test. However, I'm not convinced that this is the best course of action: My first go at a fix was to parse the pretranslation refs as source refs (which is what they should be, right, given that the `Refs` property yields the source refs as long as there are source refs which should be the case for any verse that's being pretranslated?) and then change the versification to the target when using the target as a template, but that did not work (it just flipped the issue - i.e., fail when template is set to target, works when set to source). I believe that this is because `ScriptureRef.Parse()` is happy to construct a verse that doesn't actually exist within the project's versification. That is to say, it doesn't care that the project versification is incorrect. However, the `ChangeVersification` method does care. The solution I'm giving here does solve this issue, but I'm concerned that it will ultimately cause issues elsewhere (even though tests are passing) since if you set template to target, you'll be potentially parsing source versifications as target versifications. 

It seems to me that the best solution would be to parse the pretranslation refs as source refs and convert to target versification when using target as a template and let this be an outstanding issue since this is really the fault of the project. Let me know what you all think. I can't think of a good way to implement our own versification conversion that would account for this issue since we're in a situation in which the project versification is incorrect.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/471)
<!-- Reviewable:end -->
