### PR TITLE
Call 'GetAsksById' once per DoWork

### DIFF
--- a/src/Machine/src/Serval.Machine.Shared/Usings.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Usings.cs
@@ -1,4 +1,5 @@
 global using System.Collections.Concurrent;
+global using System.Collections.Immutable;
 global using System.Data;
 global using System.Diagnostics;
 global using System.Formats.Tar;


### PR DESCRIPTION
Potential fix for https://github.com/sillsdev/serval/issues/492. @johnml1135, I'll leave potentially updating the polling interval in the deployments to you if you deem it necessary. 

Also, I think that there was a bug here where tasks would have been counted in both queues. There were no reports of this (to my knowledge) and there isn't testing that covers the logic in this class. In any case, I fixed that as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/504)
<!-- Reviewable:end -->
