### PR TITLE
Fix pretranslation filtering

### DIFF
--- a/src/Serval/src/Serval.Translation/Services/EngineService.cs
+++ b/src/Serval/src/Serval.Translation/Services/EngineService.cs
@@ -627,7 +627,7 @@ public class EngineService(
             sourceCorpus.TrainOnAll = true;
             targetCorpus.TrainOnAll = true;
         }
-        else if (trainingCorpus is not null)
+        else
         {
             if (trainingCorpus.TextIds is not null && trainingCorpus.ScriptureRange is not null)
             {
@@ -670,7 +670,7 @@ public class EngineService(
             sourceCorpus.PretranslateAll = true;
             targetCorpus.PretranslateAll = true;
         }
-        else if (pretranslateCorpus is not null)
+        else
         {
             if (pretranslateCorpus.TextIds is not null && pretranslateCorpus.ScriptureRange is not null)
             {

--- a/src/Serval/test/Serval.E2ETests/ServalApiTests.cs
+++ b/src/Serval/test/Serval.E2ETests/ServalApiTests.cs
@@ -115,14 +115,21 @@ public class ServalApiTests
         string[] books = ["MAT.txt", "1JN.txt", "2JN.txt"];
         string cId1 = await _helperClient.AddTextCorpusToEngineAsync(engineId, books, "es", "en", false);
         _helperClient.TranslationBuildConfig.TrainOn = [new() { CorpusId = cId1, TextIds = ["1JN.txt"] }];
-        string cId2 = await _helperClient.AddTextCorpusToEngineAsync(engineId, ["3JN.txt"], "es", "en", true);
+        string cId2 = await _helperClient.AddTextCorpusToEngineAsync(
+            engineId,
+            ["2JN.txt", "3JN.txt"],
+            "es",
+            "en",
+            true
+        );
+        _helperClient.TranslationBuildConfig.Pretranslate = [new() { CorpusId = cId2, TextIds = ["2JN.txt"] }];
         await _helperClient.BuildEngineAsync(engineId);
         await Task.Delay(1000);
         IList<Pretranslation> lTrans = await _helperClient.TranslationEnginesClient.GetAllPretranslationsAsync(
             engineId,
             cId2
         );
-        Assert.That(lTrans, Has.Count.EqualTo(14));
+        Assert.That(lTrans, Has.Count.EqualTo(13)); // just 2 John
     }
 
     [Test]

--- a/src/Serval/test/Serval.Translation.Tests/Services/EngineServiceTests.cs
+++ b/src/Serval/test/Serval.Translation.Tests/Services/EngineServiceTests.cs
@@ -393,6 +393,80 @@ public class EngineServiceTests
     }
 
     [Test]
+    public async Task StartBuildAsync_OneOfMultipleCorpora()
+    {
+        var env = new TestEnvironment();
+        string engineId = (await env.CreateMultipleCorporaEngineWithTextFilesAsync()).Id;
+        await env.Service.StartBuildAsync(
+            new Build
+            {
+                Id = BUILD1_ID,
+                EngineRef = engineId,
+                TrainOn = [new TrainingCorpus { CorpusRef = "corpus1" }],
+                Pretranslate = [new PretranslateCorpus { CorpusRef = "corpus1" }]
+            }
+        );
+        _ = env.TranslationServiceClient.Received()
+            .StartBuildAsync(
+                new StartBuildRequest
+                {
+                    BuildId = BUILD1_ID,
+                    EngineId = engineId,
+                    EngineType = "Smt",
+                    Corpora =
+                    {
+                        new V1.ParallelCorpus
+                        {
+                            Id = "corpus1",
+                            SourceCorpora =
+                            {
+                                new List<V1.MonolingualCorpus>
+                                {
+                                    new()
+                                    {
+                                        Language = "es",
+                                        Files =
+                                        {
+                                            new V1.CorpusFile
+                                            {
+                                                Location = "file1.txt",
+                                                Format = FileFormat.Text,
+                                                TextId = "text1"
+                                            }
+                                        },
+                                        PretranslateAll = true,
+                                        TrainOnAll = true
+                                    }
+                                }
+                            },
+                            TargetCorpora =
+                            {
+                                new List<V1.MonolingualCorpus>
+                                {
+                                    new()
+                                    {
+                                        Language = "en",
+                                        Files =
+                                        {
+                                            new V1.CorpusFile
+                                            {
+                                                Location = "file2.txt",
+                                                Format = FileFormat.Text,
+                                                TextId = "text1"
+                                            }
+                                        },
+                                        PretranslateAll = true,
+                                        TrainOnAll = true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            );
+    }
+
+    [Test]
     public async Task StartBuildAsync_TextFilesScriptureRangeSpecified()
     {
         var env = new TestEnvironment();
@@ -700,6 +774,106 @@ public class EngineServiceTests
                                         },
                                         PretranslateAll = true,
                                         TrainOnAll = true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            );
+    }
+
+    [Test]
+    public async Task StartBuildAsync_ParallelCorpus_OneOfMultipleCorpora()
+    {
+        var env = new TestEnvironment();
+        string engineId = (await env.CreateMultipleParallelCorpusEngineWithTextFilesAsync()).Id;
+        await env.Service.StartBuildAsync(
+            new Build
+            {
+                Id = BUILD1_ID,
+                EngineRef = engineId,
+                TrainOn =
+                [
+                    new TrainingCorpus
+                    {
+                        ParallelCorpusRef = "parallel-corpus1",
+                        SourceFilters = new List<ParallelCorpusFilter>()
+                        {
+                            new()
+                            {
+                                CorpusRef = "parallel-corpus1-source1",
+                                TextIds = new List<string> { "MAT" }
+                            }
+                        },
+                        TargetFilters = new List<ParallelCorpusFilter>()
+                        {
+                            new()
+                            {
+                                CorpusRef = "parallel-corpus1-target1",
+                                TextIds = new List<string> { "MAT" }
+                            }
+                        }
+                    }
+                ],
+                Pretranslate = [new PretranslateCorpus { ParallelCorpusRef = "parallel-corpus1" }]
+            }
+        );
+        _ = env.TranslationServiceClient.Received()
+            .StartBuildAsync(
+                new StartBuildRequest
+                {
+                    BuildId = BUILD1_ID,
+                    EngineId = engineId,
+                    EngineType = "Smt",
+                    Corpora =
+                    {
+                        new V1.ParallelCorpus
+                        {
+                            Id = "parallel-corpus1",
+                            SourceCorpora =
+                            {
+                                new List<V1.MonolingualCorpus>
+                                {
+                                    new()
+                                    {
+                                        Id = "parallel-corpus1-source1",
+                                        Language = "es",
+                                        TrainOnTextIds = { "MAT" },
+                                        Files =
+                                        {
+                                            new V1.CorpusFile
+                                            {
+                                                Location = "file1.txt",
+                                                Format = FileFormat.Text,
+                                                TextId = "MAT"
+                                            }
+                                        },
+                                        PretranslateAll = true,
+                                        TrainOnAll = false
+                                    }
+                                }
+                            },
+                            TargetCorpora =
+                            {
+                                new List<V1.MonolingualCorpus>
+                                {
+                                    new()
+                                    {
+                                        Id = "parallel-corpus1-target1",
+                                        Language = "en",
+                                        TrainOnTextIds = { "MAT" },
+                                        Files =
+                                        {
+                                            new V1.CorpusFile
+                                            {
+                                                Location = "file2.txt",
+                                                Format = FileFormat.Text,
+                                                TextId = "MAT"
+                                            }
+                                        },
+                                        PretranslateAll = true,
+                                        TrainOnAll = false
                                     }
                                 }
                             }
@@ -1706,6 +1880,75 @@ public class EngineServiceTests
             return engine;
         }
 
+        public async Task<Engine> CreateMultipleCorporaEngineWithTextFilesAsync()
+        {
+            var engine = new Engine
+            {
+                Id = "engine1",
+                Owner = "owner1",
+                SourceLanguage = "es",
+                TargetLanguage = "en",
+                Type = "Smt",
+                Corpora = new Models.Corpus[]
+                {
+                    new()
+                    {
+                        Id = "corpus1",
+                        SourceLanguage = "es",
+                        TargetLanguage = "en",
+                        SourceFiles =
+                        [
+                            new()
+                            {
+                                Id = "file1",
+                                Filename = "file1.txt",
+                                Format = Shared.Contracts.FileFormat.Text,
+                                TextId = "text1"
+                            }
+                        ],
+                        TargetFiles =
+                        [
+                            new()
+                            {
+                                Id = "file2",
+                                Filename = "file2.txt",
+                                Format = Shared.Contracts.FileFormat.Text,
+                                TextId = "text1"
+                            }
+                        ],
+                    },
+                    new()
+                    {
+                        Id = "corpus2",
+                        SourceLanguage = "es",
+                        TargetLanguage = "en",
+                        SourceFiles =
+                        [
+                            new()
+                            {
+                                Id = "file3",
+                                Filename = "file3.txt",
+                                Format = Shared.Contracts.FileFormat.Text,
+                                TextId = "text1"
+                            }
+                        ],
+                        TargetFiles =
+                        [
+                            new()
+                            {
+                                Id = "file4",
+                                Filename = "file4.txt",
+                                Format = Shared.Contracts.FileFormat.Text,
+                                TextId = "text1"
+                            }
+                        ],
+                    }
+                }
+            };
+            await Engines.InsertAsync(engine);
+            return engine;
+        }
+
         public async Task<Engine> CreateEngineWithParatextProjectAsync()
         {
             var engine = new Engine
@@ -1819,6 +2062,107 @@ public class EngineServiceTests
                             new()
                             {
                                 Id = "parallel-corpus1-target2",
+                                Name = "",
+                                Language = "en",
+                                Files =
+                                [
+                                    new()
+                                    {
+                                        Id = "file4",
+                                        Filename = "file4.txt",
+                                        Format = Shared.Contracts.FileFormat.Text,
+                                        TextId = "MRK"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            };
+            await Engines.InsertAsync(engine);
+            return engine;
+        }
+
+        public async Task<Engine> CreateMultipleParallelCorpusEngineWithTextFilesAsync()
+        {
+            var engine = new Engine
+            {
+                Id = "engine1",
+                Owner = "owner1",
+                SourceLanguage = "es",
+                TargetLanguage = "en",
+                Type = "Smt",
+                ParallelCorpora = new Models.ParallelCorpus[]
+                {
+                    new()
+                    {
+                        Id = "parallel-corpus1",
+                        SourceCorpora = new List<Models.MonolingualCorpus>()
+                        {
+                            new()
+                            {
+                                Id = "parallel-corpus1-source1",
+                                Name = "",
+                                Language = "es",
+                                Files =
+                                [
+                                    new()
+                                    {
+                                        Id = "file1",
+                                        Filename = "file1.txt",
+                                        Format = Shared.Contracts.FileFormat.Text,
+                                        TextId = "MAT"
+                                    }
+                                ]
+                            }
+                        },
+                        TargetCorpora = new List<Models.MonolingualCorpus>()
+                        {
+                            new()
+                            {
+                                Id = "parallel-corpus1-target1",
+                                Name = "",
+                                Language = "en",
+                                Files =
+                                [
+                                    new()
+                                    {
+                                        Id = "file2",
+                                        Filename = "file2.txt",
+                                        Format = Shared.Contracts.FileFormat.Text,
+                                        TextId = "MAT"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    new()
+                    {
+                        Id = "parallel-corpus2",
+                        SourceCorpora = new List<Models.MonolingualCorpus>()
+                        {
+                            new()
+                            {
+                                Id = "parallel-corpus2-source1",
+                                Name = "",
+                                Language = "es",
+                                Files =
+                                [
+                                    new()
+                                    {
+                                        Id = "file3",
+                                        Filename = "file3.txt",
+                                        Format = Shared.Contracts.FileFormat.Text,
+                                        TextId = "MRK"
+                                    }
+                                ]
+                            }
+                        },
+                        TargetCorpora = new List<Models.MonolingualCorpus>()
+                        {
+                            new()
+                            {
+                                Id = "parallel-corpus2-target1",
                                 Name = "",
                                 Language = "en",
                                 Files =


### PR DESCRIPTION
Don't train/pretranslate on other corpora if one is already defined.
Test for pretranslation filtering
This resolves https://github.com/sillsdev/serval/issues/516

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/520)
<!-- Reviewable:end -->
