### PR TITLE
Be able to retrieve pretranslations from parallel corpora - update filter

### DIFF
--- a/src/Serval/src/Serval.Translation/Controllers/TranslationEnginesController.cs
+++ b/src/Serval/src/Serval.Translation/Controllers/TranslationEnginesController.cs
@@ -738,7 +738,7 @@ public class TranslationEnginesController(
     {
         Engine engine = await _engineService.GetAsync(id, cancellationToken);
         await AuthorizeAsync(engine);
-        if (!engine.Corpora.Any(c => c.Id == corpusId))
+        if (!engine.Corpora.Any(c => c.Id == corpusId) && !engine.ParallelCorpora.Any(c => c.Id == corpusId))
             return NotFound();
         if (engine.ModelRevision == 0)
             return Conflict();
@@ -800,7 +800,7 @@ public class TranslationEnginesController(
     {
         Engine engine = await _engineService.GetAsync(id, cancellationToken);
         await AuthorizeAsync(engine);
-        if (!engine.Corpora.Any(c => c.Id == corpusId))
+        if (!engine.Corpora.Any(c => c.Id == corpusId) && !engine.ParallelCorpora.Any(c => c.Id == corpusId))
             return NotFound();
         if (engine.ModelRevision == 0)
             return Conflict();
@@ -875,7 +875,7 @@ public class TranslationEnginesController(
     {
         Engine engine = await _engineService.GetAsync(id, cancellationToken);
         await AuthorizeAsync(engine);
-        if (!engine.Corpora.Any(c => c.Id == corpusId))
+        if (!engine.Corpora.Any(c => c.Id == corpusId) && !engine.ParallelCorpora.Any(c => c.Id == corpusId))
             return NotFound();
         if (engine.ModelRevision == 0)
             return Conflict();

--- a/src/Serval/test/Serval.E2ETests/ServalApiTests.cs
+++ b/src/Serval/test/Serval.E2ETests/ServalApiTests.cs
@@ -213,8 +213,8 @@ public class ServalApiTests
         TranslationEngine engine = await _helperClient.TranslationEnginesClient.GetAsync(engineId);
         Assert.That(engine.IsModelPersisted, Is.True);
         string[] books = ["bible_LARGEFILE.txt"];
-        await _helperClient.AddTextCorpusToEngineAsync(engineId, books, "es", "en", false);
-        string cId = await _helperClient.AddTextCorpusToEngineAsync(engineId, ["3JN.txt"], "es", "en", true);
+        await _helperClient.AddParallelTextCorpusToEngineAsync(engineId, books, "es", "en", false);
+        string cId = await _helperClient.AddParallelTextCorpusToEngineAsync(engineId, ["3JN.txt"], "es", "en", true);
         await _helperClient.BuildEngineAsync(engineId);
         await Task.Delay(1000);
         IList<Pretranslation> lTrans = await _helperClient.TranslationEnginesClient.GetAllPretranslationsAsync(


### PR DESCRIPTION
Fixes https://github.com/sillsdev/serval/issues/522.

Make E2E test catch it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/528)
<!-- Reviewable:end -->
