### PR TITLE
Fix Filename sync issue

### DIFF
--- a/docker-compose.mongo.yml
+++ b/docker-compose.mongo.yml
@@ -15,5 +15,5 @@ services:
       [
         '/bin/sh',
         '-c',
-        'mongod --quiet --replSet myRS --bind_ip 0.0.0.0 & sleep 2s; mongosh --host localhost:27017 --eval '' config = { "_id" : "myRS", "members" : [{"_id" : 0,"host" : "mongo:27017"}] }; rs.initiate(config, { force: true }); '' ; sleep infinity'
+        'mongod --profile=2 --replSet myRS --bind_ip 0.0.0.0 & sleep 2s; mongosh --host localhost:27017 --eval '' config = { "_id" : "myRS", "members" : [{"_id" : 0,"host" : "mongo:27017"}] }; rs.initiate(config, { force: true }); '' ; sleep infinity'
       ]

--- a/src/DataAccess/src/SIL.DataAccess/ArrayPosition.cs
+++ b/src/DataAccess/src/SIL.DataAccess/ArrayPosition.cs
@@ -4,4 +4,5 @@ public static class ArrayPosition
 {
     public const int FirstMatching = int.MaxValue;
     public const int All = int.MaxValue - 1;
+    public const int ArrayFilter = int.MaxValue - 2;
 }

--- a/src/DataAccess/src/SIL.DataAccess/ArrayPosition.cs
+++ b/src/DataAccess/src/SIL.DataAccess/ArrayPosition.cs
@@ -4,5 +4,5 @@ public static class ArrayPosition
 {
     public const int FirstMatching = int.MaxValue;
     public const int All = int.MaxValue - 1;
-    public const int ArrayFilter = int.MaxValue - 2;
+    internal const int ArrayFilter = int.MaxValue - 2;
 }

--- a/src/DataAccess/src/SIL.DataAccess/DataAccessFieldDefinition.cs
+++ b/src/DataAccess/src/SIL.DataAccess/DataAccessFieldDefinition.cs
@@ -17,6 +17,10 @@ public class DataAccessFieldDefinition<TDocument, TField>(Expression<Func<TDocum
             linqProvider
         );
         string fieldName = rendered.FieldName.Replace(ArrayPosition.All.ToString(CultureInfo.InvariantCulture), "$[]");
+        fieldName = fieldName.Replace(
+            ArrayPosition.ArrayFilter.ToString(CultureInfo.InvariantCulture),
+            "$[arrayFilter]"
+        );
         fieldName = fieldName.Replace(ArrayPosition.FirstMatching.ToString(CultureInfo.InvariantCulture), "$");
         if (fieldName != rendered.FieldName)
         {

--- a/src/DataAccess/src/SIL.DataAccess/DataAccessFieldDefinition.cs
+++ b/src/DataAccess/src/SIL.DataAccess/DataAccessFieldDefinition.cs
@@ -1,9 +1,12 @@
 namespace SIL.DataAccess;
 
-public class DataAccessFieldDefinition<TDocument, TField>(Expression<Func<TDocument, TField>> expression)
-    : FieldDefinition<TDocument, TField>
+public class DataAccessFieldDefinition<TDocument, TField>(
+    Expression<Func<TDocument, TField>> expression,
+    string arrayFilterId = ""
+) : FieldDefinition<TDocument, TField>
 {
     private readonly ExpressionFieldDefinition<TDocument, TField> _internalDef = new(expression);
+    private readonly string _arrayFilterId = arrayFilterId;
 
     public override RenderedFieldDefinition<TField> Render(
         IBsonSerializer<TDocument> documentSerializer,
@@ -17,11 +20,11 @@ public class DataAccessFieldDefinition<TDocument, TField>(Expression<Func<TDocum
             linqProvider
         );
         string fieldName = rendered.FieldName.Replace(ArrayPosition.All.ToString(CultureInfo.InvariantCulture), "$[]");
+        fieldName = fieldName.Replace(ArrayPosition.FirstMatching.ToString(CultureInfo.InvariantCulture), "$");
         fieldName = fieldName.Replace(
             ArrayPosition.ArrayFilter.ToString(CultureInfo.InvariantCulture),
-            "$[arrayFilter]"
+            $"$[{_arrayFilterId}]"
         );
-        fieldName = fieldName.Replace(ArrayPosition.FirstMatching.ToString(CultureInfo.InvariantCulture), "$");
         if (fieldName != rendered.FieldName)
         {
             return new RenderedFieldDefinition<TField>(

--- a/src/DataAccess/src/SIL.DataAccess/ExpressionHelper.cs
+++ b/src/DataAccess/src/SIL.DataAccess/ExpressionHelper.cs
@@ -38,4 +38,14 @@ public static class ExpressionHelper
         finder.Visit(expression);
         return finder.Value;
     }
+
+    public static Expression<Func<TIn, TOut>> Concatenate<TIn, TInter, TOut>(
+        Expression<Func<TIn, TInter>> left,
+        Expression<Func<TInter, TOut>> right
+    )
+    {
+        ParameterReplacer replacer = new(right.Parameters[0], left.Body);
+        Expression merged = replacer.Visit(right.Body);
+        return Expression.Lambda<Func<TIn, TOut>>(merged, left.Parameters[0]);
+    }
 }

--- a/src/DataAccess/src/SIL.DataAccess/IRepository.cs
+++ b/src/DataAccess/src/SIL.DataAccess/IRepository.cs
@@ -9,6 +9,7 @@ public interface IRepository<T>
 
     Task InsertAsync(T entity, CancellationToken cancellationToken = default);
     Task InsertAllAsync(IReadOnlyCollection<T> entities, CancellationToken cancellationToken = default);
+
     Task<T?> UpdateAsync(
         Expression<Func<T, bool>> filter,
         Action<IUpdateBuilder<T>> update,
@@ -16,19 +17,12 @@ public interface IRepository<T>
         bool returnOriginal = false,
         CancellationToken cancellationToken = default
     );
-    Task<int> UpdateAllAsync<TFilter>(
-        Expression<Func<T, bool>> filter,
-        Action<IUpdateBuilder<T>> update,
-        string jsonArrayFilterDefinition,
-        CancellationToken cancellationToken = default
-    );
-
     Task<int> UpdateAllAsync(
         Expression<Func<T, bool>> filter,
         Action<IUpdateBuilder<T>> update,
-        UpdateOptions? updateOptions = null,
         CancellationToken cancellationToken = default
     );
+
     Task<T?> DeleteAsync(Expression<Func<T, bool>> filter, CancellationToken cancellationToken = default);
     Task<int> DeleteAllAsync(Expression<Func<T, bool>> filter, CancellationToken cancellationToken = default);
     Task<ISubscription<T>> SubscribeAsync(

--- a/src/DataAccess/src/SIL.DataAccess/IRepository.cs
+++ b/src/DataAccess/src/SIL.DataAccess/IRepository.cs
@@ -16,9 +16,17 @@ public interface IRepository<T>
         bool returnOriginal = false,
         CancellationToken cancellationToken = default
     );
+    Task<int> UpdateAllAsync<TFilter>(
+        Expression<Func<T, bool>> filter,
+        Action<IUpdateBuilder<T>> update,
+        string jsonArrayFilterDefinition,
+        CancellationToken cancellationToken = default
+    );
+
     Task<int> UpdateAllAsync(
         Expression<Func<T, bool>> filter,
         Action<IUpdateBuilder<T>> update,
+        UpdateOptions? updateOptions = null,
         CancellationToken cancellationToken = default
     );
     Task<T?> DeleteAsync(Expression<Func<T, bool>> filter, CancellationToken cancellationToken = default);

--- a/src/DataAccess/src/SIL.DataAccess/IUpdateBuilder.cs
+++ b/src/DataAccess/src/SIL.DataAccess/IUpdateBuilder.cs
@@ -13,10 +13,17 @@ public interface IUpdateBuilder<T>
 
     IUpdateBuilder<T> RemoveAll<TItem>(
         Expression<Func<T, IEnumerable<TItem>?>> field,
-        Expression<Func<TItem, bool>> predicate
+        Expression<Func<TItem, bool>>? predicate = null
     );
 
     IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>?>> field, TItem value);
 
     IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>?>> field, TItem value);
+
+    IUpdateBuilder<T> SetAll<TItem, TField>(
+        Expression<Func<T, IEnumerable<TItem>?>> collectionField,
+        Expression<Func<TItem, TField>> itemField,
+        TField value,
+        Expression<Func<TItem, bool>>? predicate = null
+    );
 }

--- a/src/DataAccess/src/SIL.DataAccess/MemoryRepository.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MemoryRepository.cs
@@ -233,20 +233,9 @@ public class MemoryRepository<T> : IRepository<T>
         return returnOriginal ? original : entity;
     }
 
-    public async Task<int> UpdateAllAsync<TFilter>(
-        Expression<Func<T, bool>> filter,
-        Action<IUpdateBuilder<T>> update,
-        string jsonArrayFilterDefinition,
-        CancellationToken cancellationToken = default
-    )
-    {
-        return await UpdateAllAsync(filter, update, null, cancellationToken);
-    }
-
     public async Task<int> UpdateAllAsync(
         Expression<Func<T, bool>> filter,
         Action<IUpdateBuilder<T>> update,
-        UpdateOptions? updateOptions = null,
         CancellationToken cancellationToken = default
     )
     {

--- a/src/DataAccess/src/SIL.DataAccess/MemoryRepository.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MemoryRepository.cs
@@ -233,9 +233,20 @@ public class MemoryRepository<T> : IRepository<T>
         return returnOriginal ? original : entity;
     }
 
+    public async Task<int> UpdateAllAsync<TFilter>(
+        Expression<Func<T, bool>> filter,
+        Action<IUpdateBuilder<T>> update,
+        string jsonArrayFilterDefinition,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return await UpdateAllAsync(filter, update, null, cancellationToken);
+    }
+
     public async Task<int> UpdateAllAsync(
         Expression<Func<T, bool>> filter,
         Action<IUpdateBuilder<T>> update,
+        UpdateOptions? updateOptions = null,
         CancellationToken cancellationToken = default
     )
     {

--- a/src/DataAccess/src/SIL.DataAccess/MemoryUpdateBuilder.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MemoryUpdateBuilder.cs
@@ -224,6 +224,8 @@ public class MemoryUpdateBuilder<T>(Expression<Func<T, bool>> filter, T entity, 
                                     }
                                     break;
                                 case ArrayPosition.All:
+                                // This doesn't filter as it should - but it's good enough for unit testing.
+                                case ArrayPosition.ArrayFilter:
                                     newOwners.AddRange(((IEnumerable)owner).Cast<object>());
                                     break;
                                 default:

--- a/src/DataAccess/src/SIL.DataAccess/MemoryUpdateBuilder.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MemoryUpdateBuilder.cs
@@ -264,8 +264,6 @@ public class MemoryUpdateBuilder<T>(Expression<Func<T, bool>> filter, T entity, 
                                     }
                                     break;
                                 case ArrayPosition.All:
-                                // This doesn't filter as it should - but it's good enough for unit testing.
-                                case ArrayPosition.ArrayFilter:
                                     newOwners.AddRange(((IEnumerable)owner).Cast<object>());
                                     break;
                                 default:

--- a/src/DataAccess/src/SIL.DataAccess/MongoRepository.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MongoRepository.cs
@@ -128,6 +128,8 @@ public class MongoRepository<T>(IMongoDataAccessContext context, IMongoCollectio
             IsUpsert = upsert,
             ReturnDocument = returnOriginal ? ReturnDocument.Before : ReturnDocument.After
         };
+        if (arrayFilters.Count > 0)
+            options.ArrayFilters = arrayFilters;
         T? entity;
         try
         {

--- a/src/DataAccess/src/SIL.DataAccess/MongoUpdateBuilder.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MongoUpdateBuilder.cs
@@ -3,71 +3,123 @@ namespace SIL.DataAccess;
 public class MongoUpdateBuilder<T> : IUpdateBuilder<T>
     where T : IEntity
 {
-    private readonly UpdateDefinitionBuilder<T> _updateBuilder;
-    private readonly FilterDefinitionBuilder<T> _filterBuilder;
+    private readonly UpdateDefinitionBuilder<T> _builder;
     private readonly List<UpdateDefinition<T>> _defs;
+    private readonly Dictionary<BsonDocument, (string Id, ArrayFilterDefinition<BsonValue> FilterDef)> _arrayFilters;
 
     public MongoUpdateBuilder()
     {
-        _updateBuilder = Builders<T>.Update;
-        _filterBuilder = Builders<T>.Filter;
+        _builder = Builders<T>.Update;
         _defs = new List<UpdateDefinition<T>>();
+        _arrayFilters = new Dictionary<BsonDocument, (string, ArrayFilterDefinition<BsonValue>)>();
     }
 
     public IUpdateBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField value)
     {
-        _defs.Add(_updateBuilder.Set(ToFieldDefinition(field), value));
+        _defs.Add(_builder.Set(ToFieldDefinition(field), value));
         return this;
     }
 
     public IUpdateBuilder<T> SetOnInsert<TField>(Expression<Func<T, TField>> field, TField value)
     {
-        _defs.Add(_updateBuilder.SetOnInsert(ToFieldDefinition(field), value));
+        _defs.Add(_builder.SetOnInsert(ToFieldDefinition(field), value));
         return this;
     }
 
     public IUpdateBuilder<T> Unset<TField>(Expression<Func<T, TField>> field)
     {
-        _defs.Add(_updateBuilder.Unset(ToFieldDefinition(field)));
+        _defs.Add(_builder.Unset(ToFieldDefinition(field)));
         return this;
     }
 
     public IUpdateBuilder<T> Inc(Expression<Func<T, int>> field, int value = 1)
     {
-        _defs.Add(_updateBuilder.Inc(ToFieldDefinition(field), value));
+        _defs.Add(_builder.Inc(ToFieldDefinition(field), value));
         return this;
     }
 
     public IUpdateBuilder<T> RemoveAll<TItem>(
         Expression<Func<T, IEnumerable<TItem>?>> field,
-        Expression<Func<TItem, bool>> predicate
+        Expression<Func<TItem, bool>>? predicate = null
     )
     {
-        _defs.Add(_updateBuilder.PullFilter(ToFieldDefinition(field), Builders<TItem>.Filter.Where(predicate)));
+        _defs.Add(_builder.PullFilter(ToFieldDefinition(field), Builders<TItem>.Filter.Where(predicate)));
         return this;
     }
 
     public IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>?>> field, TItem value)
     {
-        _defs.Add(_updateBuilder.Pull(ToFieldDefinition(field), value));
+        _defs.Add(_builder.Pull(ToFieldDefinition(field), value));
         return this;
     }
 
     public IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>?>> field, TItem value)
     {
-        _defs.Add(_updateBuilder.Push(ToFieldDefinition(field), value));
+        _defs.Add(_builder.Push(ToFieldDefinition(field), value));
         return this;
     }
 
-    public UpdateDefinition<T> Build()
+    public IUpdateBuilder<T> SetAll<TItem, TField>(
+        Expression<Func<T, IEnumerable<TItem>?>> collectionField,
+        Expression<Func<TItem, TField>> itemField,
+        TField value,
+        Expression<Func<TItem, bool>>? predicate = null
+    )
     {
-        if (_defs.Count == 1)
-            return _defs.Single();
-        return _updateBuilder.Combine(_defs);
+        Expression<Func<T, TItem>> itemExpr = ExpressionHelper.Concatenate(
+            collectionField,
+            (collection) => ((IReadOnlyList<TItem>?)collection)![ArrayPosition.ArrayFilter]
+        );
+        Expression<Func<T, TField>> fieldExpr = ExpressionHelper.Concatenate(itemExpr, itemField);
+        if (predicate != null)
+        {
+            ExpressionFilterDefinition<TItem> filter = new(predicate);
+            BsonDocument bsonDoc = filter.Render(
+                BsonSerializer.SerializerRegistry.GetSerializer<TItem>(),
+                BsonSerializer.SerializerRegistry,
+                LinqProvider.V2
+            );
+            string filterId;
+            if (_arrayFilters.TryGetValue(bsonDoc, out var existingArrayFilter))
+            {
+                filterId = existingArrayFilter.Id;
+            }
+            else
+            {
+                filterId = "f" + ObjectId.GenerateNewId().ToString();
+                _arrayFilters.Add(
+                    bsonDoc,
+                    (
+                        filterId,
+                        new BsonDocument(
+                            $"{filterId}.{bsonDoc.Elements.Single().Name}",
+                            bsonDoc.Elements.Single().Value
+                        )
+                    )
+                );
+            }
+            _defs.Add(_builder.Set(ToFieldDefinition(fieldExpr, filterId), value));
+        }
+        else
+        {
+            _defs.Add(_builder.Set(ToFieldDefinition(fieldExpr), value));
+        }
+        return this;
     }
 
-    private static FieldDefinition<T, TField> ToFieldDefinition<TField>(Expression<Func<T, TField>> field)
+    public (UpdateDefinition<T>, IReadOnlyList<ArrayFilterDefinition>) Build()
     {
-        return new DataAccessFieldDefinition<T, TField>(field);
+        ArrayFilterDefinition[] arrayFilters = _arrayFilters.Values.Select(f => f.FilterDef).ToArray();
+        if (_defs.Count == 1)
+            return (_defs.Single(), arrayFilters);
+        return (_builder.Combine(_defs), arrayFilters);
+    }
+
+    private static FieldDefinition<T, TField> ToFieldDefinition<TField>(
+        Expression<Func<T, TField>> field,
+        string arrayFilterId = ""
+    )
+    {
+        return new DataAccessFieldDefinition<T, TField>(field, arrayFilterId);
     }
 }

--- a/src/DataAccess/src/SIL.DataAccess/MongoUpdateBuilder.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MongoUpdateBuilder.cs
@@ -3,36 +3,38 @@ namespace SIL.DataAccess;
 public class MongoUpdateBuilder<T> : IUpdateBuilder<T>
     where T : IEntity
 {
-    private readonly UpdateDefinitionBuilder<T> _builder;
+    private readonly UpdateDefinitionBuilder<T> _updateBuilder;
+    private readonly FilterDefinitionBuilder<T> _filterBuilder;
     private readonly List<UpdateDefinition<T>> _defs;
 
     public MongoUpdateBuilder()
     {
-        _builder = Builders<T>.Update;
+        _updateBuilder = Builders<T>.Update;
+        _filterBuilder = Builders<T>.Filter;
         _defs = new List<UpdateDefinition<T>>();
     }
 
     public IUpdateBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField value)
     {
-        _defs.Add(_builder.Set(ToFieldDefinition(field), value));
+        _defs.Add(_updateBuilder.Set(ToFieldDefinition(field), value));
         return this;
     }
 
     public IUpdateBuilder<T> SetOnInsert<TField>(Expression<Func<T, TField>> field, TField value)
     {
-        _defs.Add(_builder.SetOnInsert(ToFieldDefinition(field), value));
+        _defs.Add(_updateBuilder.SetOnInsert(ToFieldDefinition(field), value));
         return this;
     }
 
     public IUpdateBuilder<T> Unset<TField>(Expression<Func<T, TField>> field)
     {
-        _defs.Add(_builder.Unset(ToFieldDefinition(field)));
+        _defs.Add(_updateBuilder.Unset(ToFieldDefinition(field)));
         return this;
     }
 
     public IUpdateBuilder<T> Inc(Expression<Func<T, int>> field, int value = 1)
     {
-        _defs.Add(_builder.Inc(ToFieldDefinition(field), value));
+        _defs.Add(_updateBuilder.Inc(ToFieldDefinition(field), value));
         return this;
     }
 
@@ -41,19 +43,19 @@ public class MongoUpdateBuilder<T> : IUpdateBuilder<T>
         Expression<Func<TItem, bool>> predicate
     )
     {
-        _defs.Add(_builder.PullFilter(ToFieldDefinition(field), Builders<TItem>.Filter.Where(predicate)));
+        _defs.Add(_updateBuilder.PullFilter(ToFieldDefinition(field), Builders<TItem>.Filter.Where(predicate)));
         return this;
     }
 
     public IUpdateBuilder<T> Remove<TItem>(Expression<Func<T, IEnumerable<TItem>?>> field, TItem value)
     {
-        _defs.Add(_builder.Pull(ToFieldDefinition(field), value));
+        _defs.Add(_updateBuilder.Pull(ToFieldDefinition(field), value));
         return this;
     }
 
     public IUpdateBuilder<T> Add<TItem>(Expression<Func<T, IEnumerable<TItem>?>> field, TItem value)
     {
-        _defs.Add(_builder.Push(ToFieldDefinition(field), value));
+        _defs.Add(_updateBuilder.Push(ToFieldDefinition(field), value));
         return this;
     }
 
@@ -61,7 +63,7 @@ public class MongoUpdateBuilder<T> : IUpdateBuilder<T>
     {
         if (_defs.Count == 1)
             return _defs.Single();
-        return _builder.Combine(_defs);
+        return _updateBuilder.Combine(_defs);
     }
 
     private static FieldDefinition<T, TField> ToFieldDefinition<TField>(Expression<Func<T, TField>> field)

--- a/src/DataAccess/src/SIL.DataAccess/ParameterReplacer.cs
+++ b/src/DataAccess/src/SIL.DataAccess/ParameterReplacer.cs
@@ -1,0 +1,16 @@
+﻿namespace SIL.DataAccess;
+
+internal class ParameterReplacer(ParameterExpression oldExpression, Expression newExpression)
+    : System.Linq.Expressions.ExpressionVisitor
+{
+    private readonly ParameterExpression _oldExpression = oldExpression;
+    private readonly Expression _newExpression = newExpression;
+
+    protected override Expression VisitParameter(ParameterExpression node)
+    {
+        if (node == _oldExpression)
+            return _newExpression;
+
+        return base.VisitParameter(node);
+    }
+}

--- a/src/DataAccess/test/SIL.DataAccess.Tests/MemoryRepositoryTests.cs
+++ b/src/DataAccess/test/SIL.DataAccess.Tests/MemoryRepositoryTests.cs
@@ -294,6 +294,30 @@ public class MemoryRepositoryTests
     }
 
     [Test]
+    public async Task UpdateAsync_SetAll()
+    {
+        MemoryRepository<TestEntity> repo = new();
+        repo.Add(
+            new TestEntity()
+            {
+                Id = "1",
+                Children = [new Child { Field = 1 }, new Child { Field = 2 }, new Child { Field = 3 }]
+            }
+        );
+
+        TestEntity? entity = await repo.UpdateAsync(
+            "1",
+            u => u.SetAll(e => e.Children, c => c.Field, 0, c => c.Field >= 2)
+        );
+
+        Assert.That(entity, Is.Not.Null);
+        Assert.That(entity.Children, Is.Not.Null);
+        Assert.That(entity.Children[0].Field, Is.EqualTo(1));
+        Assert.That(entity.Children[1].Field, Is.EqualTo(0));
+        Assert.That(entity.Children[2].Field, Is.EqualTo(0));
+    }
+
+    [Test]
     public async Task DeleteAsync_DoesNotExist()
     {
         MemoryRepository<TestEntity> repo = new();
@@ -349,5 +373,11 @@ public class MemoryRepositoryTests
         public List<int>? List { get; init; }
         public int[]? Array { get; init; }
         public ReadOnlyCollection<int>? ReadOnlyCollection { get; init; }
+        public IReadOnlyList<Child>? Children { get; init; }
+    }
+
+    private record Child
+    {
+        public int Field { get; init; }
     }
 }

--- a/src/Machine/src/Serval.Machine.Shared/Services/DistributedReaderWriterLockFactory.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/DistributedReaderWriterLockFactory.cs
@@ -55,7 +55,7 @@ public class DistributedReaderWriterLockFactory(
         await _locks.UpdateAllAsync(
             rwl => rwl.WriterLock != null && rwl.WriterLock.HostId == _serviceOptions.ServiceId,
             u => u.Unset(rwl => rwl.WriterLock),
-            cancellationToken
+            cancellationToken: cancellationToken
         );
     }
 
@@ -64,7 +64,7 @@ public class DistributedReaderWriterLockFactory(
         await _locks.UpdateAllAsync(
             rwl => rwl.ReaderLocks.Any(l => l.HostId == _serviceOptions.ServiceId),
             u => u.RemoveAll(rwl => rwl.ReaderLocks, l => l.HostId == _serviceOptions.ServiceId),
-            cancellationToken
+            cancellationToken: cancellationToken
         );
     }
 
@@ -73,7 +73,7 @@ public class DistributedReaderWriterLockFactory(
         await _locks.UpdateAllAsync(
             rwl => rwl.WriterQueue.Any(l => l.HostId == _serviceOptions.ServiceId),
             u => u.RemoveAll(rwl => rwl.WriterQueue, l => l.HostId == _serviceOptions.ServiceId),
-            cancellationToken
+            cancellationToken: cancellationToken
         );
     }
 }

--- a/src/Serval/src/Serval.Client/Client.g.cs
+++ b/src/Serval/src/Serval.Client/Client.g.cs
@@ -7073,9 +7073,37 @@ namespace Serval.Client
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.1.0.0 (NJsonSchema v11.0.2.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class CorpusFile
     {
-        [Newtonsoft.Json.JsonProperty("file", Required = Newtonsoft.Json.Required.Always)]
+        [Newtonsoft.Json.JsonProperty("fileId", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string FileId { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("textId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? TextId { get; set; } = default!;
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.1.0.0 (NJsonSchema v11.0.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class CorpusConfig
+    {
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? Name { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("language", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string Language { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("files", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
-        public DataFile File { get; set; } = new DataFile();
+        public System.Collections.Generic.IList<CorpusFileConfig> Files { get; set; } = new System.Collections.ObjectModel.Collection<CorpusFileConfig>();
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.1.0.0 (NJsonSchema v11.0.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class CorpusFileConfig
+    {
+        [Newtonsoft.Json.JsonProperty("fileId", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string FileId { get; set; } = default!;
 
         [Newtonsoft.Json.JsonProperty("textId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string? TextId { get; set; } = default!;
@@ -7115,34 +7143,6 @@ namespace Serval.Client
 
         [System.Runtime.Serialization.EnumMember(Value = @"Paratext")]
         Paratext = 1,
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.1.0.0 (NJsonSchema v11.0.2.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class CorpusConfig
-    {
-        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string? Name { get; set; } = default!;
-
-        [Newtonsoft.Json.JsonProperty("language", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string Language { get; set; } = default!;
-
-        [Newtonsoft.Json.JsonProperty("files", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
-        public System.Collections.Generic.IList<CorpusFileConfig> Files { get; set; } = new System.Collections.ObjectModel.Collection<CorpusFileConfig>();
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.1.0.0 (NJsonSchema v11.0.2.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class CorpusFileConfig
-    {
-        [Newtonsoft.Json.JsonProperty("fileId", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
-        public string FileId { get; set; } = default!;
-
-        [Newtonsoft.Json.JsonProperty("textId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string? TextId { get; set; } = default!;
 
     }
 

--- a/src/Serval/src/Serval.DataFiles/Contracts/CorpusFileDto.cs
+++ b/src/Serval/src/Serval.DataFiles/Contracts/CorpusFileDto.cs
@@ -2,6 +2,6 @@ namespace Serval.DataFiles.Contracts;
 
 public record CorpusFileDto
 {
-    public required DataFileDto File { get; init; }
+    public required string FileId { get; init; }
     public string? TextId { get; init; }
 }

--- a/src/Serval/src/Serval.DataFiles/Controllers/CorporaController.cs
+++ b/src/Serval/src/Serval.DataFiles/Controllers/CorporaController.cs
@@ -177,7 +177,7 @@ public class CorporaController(
             DataFile? dataFile = await _dataFileService.GetAsync(file.FileId, cancellationToken);
             if (dataFile == null)
                 throw new InvalidOperationException($"DataFile with id {file.FileId} does not exist.");
-            dataFiles.Add(new CorpusFile { File = dataFile, TextId = file.TextId });
+            dataFiles.Add(new CorpusFile { FileId = file.FileId, TextId = file.TextId });
         }
         return dataFiles;
     }
@@ -197,18 +197,6 @@ public class CorporaController(
 
     private CorpusFileDto Map(CorpusFile source)
     {
-        return new CorpusFileDto { File = Map(source.File), TextId = source.TextId };
-    }
-
-    private DataFileDto Map(DataFile source)
-    {
-        return new DataFileDto
-        {
-            Id = source.Id,
-            Url = _urlService.GetUrl(Endpoints.GetDataFile, new { id = source.Id }),
-            Name = source.Name,
-            Format = source.Format,
-            Revision = source.Revision
-        };
+        return new CorpusFileDto { FileId = source.FileId, TextId = source.TextId };
     }
 }

--- a/src/Serval/src/Serval.DataFiles/Models/CorpusFile.cs
+++ b/src/Serval/src/Serval.DataFiles/Models/CorpusFile.cs
@@ -2,6 +2,6 @@ namespace Serval.DataFiles.Models;
 
 public record CorpusFile
 {
-    public required DataFile File { get; init; }
+    public required string FileId { get; init; }
     public string? TextId { get; init; }
 }

--- a/src/Serval/src/Serval.DataFiles/Services/CorpusService.cs
+++ b/src/Serval/src/Serval.DataFiles/Services/CorpusService.cs
@@ -1,7 +1,17 @@
 namespace Serval.DataFiles.Services;
 
-public class CorpusService(IRepository<Corpus> corpora) : OwnedEntityServiceBase<Corpus>(corpora), ICorpusService
+public class CorpusService(
+    IRepository<Corpus> corpora,
+    IDataAccessContext dataAccessContext,
+    IDataFileService dataFileService,
+    IScopedMediator mediator
+) : OwnedEntityServiceBase<Corpus>(corpora), ICorpusService
 {
+    private readonly IDataAccessContext _dataAccessContext = dataAccessContext;
+    private readonly IDataFileService _dataFileService = dataFileService;
+
+    private readonly IScopedMediator _mediator = mediator;
+
     public async Task<Corpus> GetAsync(string id, string owner, CancellationToken cancellationToken = default)
     {
         Corpus? corpus = await Entities.GetAsync(c => c.Id == id && c.Owner == owner, cancellationToken);
@@ -16,13 +26,44 @@ public class CorpusService(IRepository<Corpus> corpora) : OwnedEntityServiceBase
         CancellationToken cancellationToken = default
     )
     {
-        Corpus? corpus = await Entities.UpdateAsync(
-            c => c.Id == id,
-            u => u.Set(c => c.Files, files),
-            cancellationToken: cancellationToken
+        return await _dataAccessContext.WithTransactionAsync(
+            async (ct) =>
+            {
+                Corpus? corpus = await Entities.UpdateAsync(
+                    c => c.Id == id,
+                    u => u.Set(c => c.Files, files),
+                    cancellationToken: cancellationToken
+                );
+                if (corpus is null)
+                    throw new EntityNotFoundException($"Could not find Corpus '{id}.");
+                await _mediator.Publish(
+                    new CorpusUpdated
+                    {
+                        CorpusId = corpus.Id,
+                        Files = await Task.WhenAll(
+                            corpus.Files.Select(async f => new CorpusFileResult
+                            {
+                                TextId = f.TextId!,
+                                File = Map(await _dataFileService.GetAsync(f.FileId))
+                            })
+                        )
+                    },
+                    ct
+                );
+                return corpus;
+            },
+            cancellationToken
         );
-        if (corpus is null)
-            throw new EntityNotFoundException($"Could not find Corpus '{id}.");
-        return corpus;
+    }
+
+    private static DataFileResult Map(DataFile dataFile)
+    {
+        return new DataFileResult
+        {
+            DataFileId = dataFile.Id,
+            Name = dataFile.Name,
+            Filename = dataFile.Filename,
+            Format = dataFile.Format,
+        };
     }
 }

--- a/src/Serval/src/Serval.DataFiles/Services/DataFileService.cs
+++ b/src/Serval/src/Serval.DataFiles/Services/DataFileService.cs
@@ -89,6 +89,7 @@ public class DataFileService : OwnedEntityServiceBase<DataFile>, IDataFileServic
                             cancellationToken: ct
                         );
                     }
+                    await _mediator.Publish(new DataFileUpdated { DataFileId = id, Filename = filename }, ct);
                 },
                 cancellationToken: cancellationToken
             );

--- a/src/Serval/src/Serval.Shared/Contracts/CorpusUpdated.cs
+++ b/src/Serval/src/Serval.Shared/Contracts/CorpusUpdated.cs
@@ -1,0 +1,7 @@
+﻿namespace Serval.Shared.Contracts;
+
+public record CorpusUpdated
+{
+    public required string CorpusId { get; init; }
+    public required IReadOnlyList<CorpusFileResult> Files { get; init; }
+}

--- a/src/Serval/src/Serval.Shared/Contracts/DataFileUpdated.cs
+++ b/src/Serval/src/Serval.Shared/Contracts/DataFileUpdated.cs
@@ -3,4 +3,5 @@
 public record DataFileUpdated
 {
     public required string DataFileId { get; init; }
+    public required string Filename { get; init; }
 }

--- a/src/Serval/src/Serval.Translation/Configuration/IMediatorRegistrationConfiguratorExtensions.cs
+++ b/src/Serval/src/Serval.Translation/Configuration/IMediatorRegistrationConfiguratorExtensions.cs
@@ -7,6 +7,8 @@ public static class IMediatorRegistrationConfiguratorExtensions
     )
     {
         configurator.AddConsumer<DataFileDeletedConsumer>();
+        configurator.AddConsumer<DataFileUpdatedConsumer>();
+        configurator.AddConsumer<CorpusUpdatedConsumer>();
         return configurator;
     }
 }

--- a/src/Serval/src/Serval.Translation/Consumers/CorpusUpdatedConsumer.cs
+++ b/src/Serval/src/Serval.Translation/Consumers/CorpusUpdatedConsumer.cs
@@ -1,0 +1,26 @@
+﻿namespace Serval.Translation.Consumers;
+
+public class CorpusUpdatedConsumer(IEngineService engineService) : IConsumer<CorpusUpdated>
+{
+    private readonly IEngineService _engineService = engineService;
+
+    public async Task Consume(ConsumeContext<CorpusUpdated> context)
+    {
+        await _engineService.UpdateCorpusFilesAsync(
+            context.Message.CorpusId,
+            context.Message.Files.Select(Map).ToList(),
+            context.CancellationToken
+        );
+    }
+
+    private static CorpusFile Map(CorpusFileResult corpusFile)
+    {
+        return new CorpusFile
+        {
+            Id = corpusFile.File.DataFileId,
+            TextId = corpusFile.TextId,
+            Filename = corpusFile.File.Filename,
+            Format = corpusFile.File.Format,
+        };
+    }
+}

--- a/src/Serval/src/Serval.Translation/Consumers/DataFileUpdatedConsumer.cs
+++ b/src/Serval/src/Serval.Translation/Consumers/DataFileUpdatedConsumer.cs
@@ -1,0 +1,15 @@
+﻿namespace Serval.Translation.Consumers;
+
+public class DataFileUpdatedConsumer(IEngineService engineService) : IConsumer<DataFileUpdated>
+{
+    private readonly IEngineService _engineService = engineService;
+
+    public async Task Consume(ConsumeContext<DataFileUpdated> context)
+    {
+        await _engineService.UpdateDataFileFilenameFilesAsync(
+            context.Message.DataFileId,
+            context.Message.Filename,
+            context.CancellationToken
+        );
+    }
+}

--- a/src/Serval/src/Serval.Translation/Services/EngineService.cs
+++ b/src/Serval/src/Serval.Translation/Services/EngineService.cs
@@ -567,16 +567,18 @@ public class EngineService(
                     || c.TargetCorpora.Any(mc => mc.Files.Any(f => f.Id == dataFileId))
                 ),
             u =>
-                u.RemoveAll(e => e.Corpora[ArrayPosition.All].SourceFiles, f => f.Id == dataFileId)
-                    .RemoveAll(e => e.Corpora[ArrayPosition.All].TargetFiles, f => f.Id == dataFileId)
-                    .RemoveAll(
-                        e => e.ParallelCorpora[ArrayPosition.All].SourceCorpora[ArrayPosition.All].Files,
-                        f => f.Id == dataFileId
-                    )
-                    .RemoveAll(
-                        e => e.ParallelCorpora[ArrayPosition.All].TargetCorpora[ArrayPosition.All].Files,
-                        f => f.Id == dataFileId
-                    ),
+            {
+                u.RemoveAll(e => e.Corpora[ArrayPosition.All].SourceFiles, f => f.Id == dataFileId);
+                u.RemoveAll(e => e.Corpora[ArrayPosition.All].TargetFiles, f => f.Id == dataFileId);
+                u.RemoveAll(
+                    e => e.ParallelCorpora[ArrayPosition.All].SourceCorpora[ArrayPosition.All].Files,
+                    f => f.Id == dataFileId
+                );
+                u.RemoveAll(
+                    e => e.ParallelCorpora[ArrayPosition.All].TargetCorpora[ArrayPosition.All].Files,
+                    f => f.Id == dataFileId
+                );
+            },
             cancellationToken: cancellationToken
         );
     }
@@ -587,7 +589,7 @@ public class EngineService(
         CancellationToken cancellationToken = default
     )
     {
-        return Entities.UpdateAllAsync<Models.CorpusFile>(
+        return Entities.UpdateAllAsync(
             e =>
                 e.Corpora.Any(c =>
                     c.SourceFiles.Any(f => f.Id == dataFileId) || c.TargetFiles.Any(f => f.Id == dataFileId)
@@ -597,25 +599,32 @@ public class EngineService(
                     || c.TargetCorpora.Any(mc => mc.Files.Any(f => f.Id == dataFileId))
                 ),
             u =>
-                u.Set(e => e.Corpora[ArrayPosition.All].SourceFiles[ArrayPosition.ArrayFilter].Filename, filename)
-                    .Set(e => e.Corpora[ArrayPosition.All].TargetFiles[ArrayPosition.ArrayFilter].Filename, filename)
-                    .Set(
-                        e =>
-                            e.ParallelCorpora[ArrayPosition.All]
-                                .SourceCorpora[ArrayPosition.All]
-                                .Files[ArrayPosition.ArrayFilter]
-                                .Filename,
-                        filename
-                    )
-                    .Set(
-                        e =>
-                            e.ParallelCorpora[ArrayPosition.All]
-                                .TargetCorpora[ArrayPosition.All]
-                                .Files[ArrayPosition.ArrayFilter]
-                                .Filename,
-                        filename
-                    ),
-            jsonArrayFilterDefinition: $"{{ \"arrayFilter._id\": {{$eq: ObjectId(\"{dataFileId}\") }} }}",
+            {
+                u.SetAll(
+                    e => e.Corpora[ArrayPosition.All].SourceFiles,
+                    f => f.Filename,
+                    filename,
+                    f => f.Id == dataFileId
+                );
+                u.SetAll(
+                    e => e.Corpora[ArrayPosition.All].TargetFiles,
+                    f => f.Filename,
+                    filename,
+                    f => f.Id == dataFileId
+                );
+                u.SetAll(
+                    e => e.ParallelCorpora[ArrayPosition.All].SourceCorpora[ArrayPosition.All].Files,
+                    f => f.Filename,
+                    filename,
+                    f => f.Id == dataFileId
+                );
+                u.SetAll(
+                    e => e.ParallelCorpora[ArrayPosition.All].TargetCorpora[ArrayPosition.All].Files,
+                    f => f.Filename,
+                    filename,
+                    f => f.Id == dataFileId
+                );
+            },
             cancellationToken: cancellationToken
         );
     }
@@ -626,18 +635,26 @@ public class EngineService(
         CancellationToken cancellationToken = default
     )
     {
-        return Entities.UpdateAllAsync<Models.MonolingualCorpus>(
+        return Entities.UpdateAllAsync(
             e =>
                 e.ParallelCorpora.Any(c =>
                     c.SourceCorpora.Any(mc => mc.Id == corpusId) || c.TargetCorpora.Any(mc => mc.Id == corpusId)
                 ),
             u =>
-                u.Set(e => e.ParallelCorpora[ArrayPosition.All].SourceCorpora[ArrayPosition.ArrayFilter].Files, files)
-                    .Set(
-                        e => e.ParallelCorpora[ArrayPosition.All].TargetCorpora[ArrayPosition.ArrayFilter].Files,
-                        files
-                    ),
-            jsonArrayFilterDefinition: $"{{ \"arrayFilter._id\": {{$eq: ObjectId(\"{corpusId}\") }} }}",
+            {
+                u.SetAll(
+                    e => e.ParallelCorpora[ArrayPosition.All].SourceCorpora,
+                    mc => mc.Files,
+                    files,
+                    mc => mc.Id == corpusId
+                );
+                u.SetAll(
+                    e => e.ParallelCorpora[ArrayPosition.All].TargetCorpora,
+                    mc => mc.Files,
+                    files,
+                    mc => mc.Id == corpusId
+                );
+            },
             cancellationToken: cancellationToken
         );
     }

--- a/src/Serval/src/Serval.Translation/Services/EngineService.cs
+++ b/src/Serval/src/Serval.Translation/Services/EngineService.cs
@@ -561,11 +561,84 @@ public class EngineService(
             e =>
                 e.Corpora.Any(c =>
                     c.SourceFiles.Any(f => f.Id == dataFileId) || c.TargetFiles.Any(f => f.Id == dataFileId)
+                )
+                || e.ParallelCorpora.Any(c =>
+                    c.SourceCorpora.Any(mc => mc.Files.Any(f => f.Id == dataFileId))
+                    || c.TargetCorpora.Any(mc => mc.Files.Any(f => f.Id == dataFileId))
                 ),
             u =>
                 u.RemoveAll(e => e.Corpora[ArrayPosition.All].SourceFiles, f => f.Id == dataFileId)
-                    .RemoveAll(e => e.Corpora[ArrayPosition.All].TargetFiles, f => f.Id == dataFileId),
-            cancellationToken
+                    .RemoveAll(e => e.Corpora[ArrayPosition.All].TargetFiles, f => f.Id == dataFileId)
+                    .RemoveAll(
+                        e => e.ParallelCorpora[ArrayPosition.All].SourceCorpora[ArrayPosition.All].Files,
+                        f => f.Id == dataFileId
+                    )
+                    .RemoveAll(
+                        e => e.ParallelCorpora[ArrayPosition.All].TargetCorpora[ArrayPosition.All].Files,
+                        f => f.Id == dataFileId
+                    ),
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public Task UpdateDataFileFilenameFilesAsync(
+        string dataFileId,
+        string filename,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return Entities.UpdateAllAsync<Models.CorpusFile>(
+            e =>
+                e.Corpora.Any(c =>
+                    c.SourceFiles.Any(f => f.Id == dataFileId) || c.TargetFiles.Any(f => f.Id == dataFileId)
+                )
+                || e.ParallelCorpora.Any(c =>
+                    c.SourceCorpora.Any(mc => mc.Files.Any(f => f.Id == dataFileId))
+                    || c.TargetCorpora.Any(mc => mc.Files.Any(f => f.Id == dataFileId))
+                ),
+            u =>
+                u.Set(e => e.Corpora[ArrayPosition.All].SourceFiles[ArrayPosition.ArrayFilter].Filename, filename)
+                    .Set(e => e.Corpora[ArrayPosition.All].TargetFiles[ArrayPosition.ArrayFilter].Filename, filename)
+                    .Set(
+                        e =>
+                            e.ParallelCorpora[ArrayPosition.All]
+                                .SourceCorpora[ArrayPosition.All]
+                                .Files[ArrayPosition.ArrayFilter]
+                                .Filename,
+                        filename
+                    )
+                    .Set(
+                        e =>
+                            e.ParallelCorpora[ArrayPosition.All]
+                                .TargetCorpora[ArrayPosition.All]
+                                .Files[ArrayPosition.ArrayFilter]
+                                .Filename,
+                        filename
+                    ),
+            jsonArrayFilterDefinition: $"{{ \"arrayFilter._id\": {{$eq: ObjectId(\"{dataFileId}\") }} }}",
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public Task UpdateCorpusFilesAsync(
+        string corpusId,
+        IReadOnlyList<Models.CorpusFile> files,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return Entities.UpdateAllAsync<Models.MonolingualCorpus>(
+            e =>
+                e.ParallelCorpora.Any(c =>
+                    c.SourceCorpora.Any(mc => mc.Id == corpusId) || c.TargetCorpora.Any(mc => mc.Id == corpusId)
+                ),
+            u =>
+                u.Set(e => e.ParallelCorpora[ArrayPosition.All].SourceCorpora[ArrayPosition.ArrayFilter].Files, files)
+                    .Set(
+                        e => e.ParallelCorpora[ArrayPosition.All].TargetCorpora[ArrayPosition.ArrayFilter].Files,
+                        files
+                    ),
+            jsonArrayFilterDefinition: $"{{ \"arrayFilter._id\": {{$eq: ObjectId(\"{corpusId}\") }} }}",
+            cancellationToken: cancellationToken
         );
     }
 

--- a/src/Serval/src/Serval.Translation/Services/IEngineService.cs
+++ b/src/Serval/src/Serval.Translation/Services/IEngineService.cs
@@ -68,6 +68,18 @@ public interface IEngineService
 
     Task DeleteAllCorpusFilesAsync(string dataFileId, CancellationToken cancellationToken = default);
 
+    Task UpdateDataFileFilenameFilesAsync(
+        string dataFileId,
+        string filename,
+        CancellationToken cancellationToken = default
+    );
+
+    Task UpdateCorpusFilesAsync(
+        string corpusId,
+        IReadOnlyList<CorpusFile> files,
+        CancellationToken cancellationToken = default
+    );
+
     Task<Queue> GetQueueAsync(string engineType, CancellationToken cancellationToken = default);
 
     Task<LanguageInfo> GetLanguageInfoAsync(

--- a/src/Serval/test/Serval.ApiServer.IntegrationTests/TranslationEngineTests.cs
+++ b/src/Serval/test/Serval.ApiServer.IntegrationTests/TranslationEngineTests.cs
@@ -2048,10 +2048,7 @@ public class TranslationEngineTests
         Assert.That(orgCorpusFromRepo.Files[0].FileId, Is.EqualTo(FILE2_TRG_ID));
 
         // Update the file
-        await dataFilesClient.UpdateAsync(
-            FILE1_SRC_ID,
-            new FileParameter(new MemoryStream(new byte[] { 1, 2, 3 }), "test.txt")
-        );
+        await dataFilesClient.UpdateAsync(FILE1_SRC_ID, new FileParameter(new MemoryStream([1, 2, 3]), "test.txt"));
         await corporaClient.UpdateAsync(
             TARGET_CORPUS_ID,
             [new CorpusFileConfig { FileId = FILE4_TRG_ZIP_ID, TextId = "all" }]

--- a/src/Serval/test/Serval.ApiServer.IntegrationTests/TranslationEngineTests.cs
+++ b/src/Serval/test/Serval.ApiServer.IntegrationTests/TranslationEngineTests.cs
@@ -19,11 +19,11 @@ public class TranslationEngineTests
             TargetLanguage = "en",
             SourceFiles =
             {
-                new TranslationCorpusFileConfig { FileId = FILE1_ID, TextId = "all" }
+                new TranslationCorpusFileConfig { FileId = FILE1_SRC_ID, TextId = "all" }
             },
             TargetFiles =
             {
-                new TranslationCorpusFileConfig { FileId = FILE2_ID, TextId = "all" }
+                new TranslationCorpusFileConfig { FileId = FILE2_TRG_ID, TextId = "all" }
             }
         };
     private static readonly TranslationParallelCorpusConfig TestParallelCorpusConfig =
@@ -49,11 +49,11 @@ public class TranslationEngineTests
             TargetLanguage = "es",
             SourceFiles =
             {
-                new TranslationCorpusFileConfig { FileId = FILE1_ID, TextId = "all" }
+                new TranslationCorpusFileConfig { FileId = FILE1_SRC_ID, TextId = "all" }
             },
             TargetFiles =
             {
-                new TranslationCorpusFileConfig { FileId = FILE2_ID, TextId = "all" }
+                new TranslationCorpusFileConfig { FileId = FILE2_TRG_ID, TextId = "all" }
             }
         };
 
@@ -63,8 +63,8 @@ public class TranslationEngineTests
             Name = "TestCorpus",
             SourceLanguage = "en",
             TargetLanguage = "en",
-            SourceFiles = { new TranslationCorpusFileConfig { FileId = FILE3_ID } },
-            TargetFiles = { new TranslationCorpusFileConfig { FileId = FILE4_ID } }
+            SourceFiles = { new TranslationCorpusFileConfig { FileId = FILE3_SRC_ZIP_ID } },
+            TargetFiles = { new TranslationCorpusFileConfig { FileId = FILE4_TRG_ZIP_ID } }
         };
 
     private const string ECHO_ENGINE1_ID = "e00000000000000000000001";
@@ -72,13 +72,13 @@ public class TranslationEngineTests
     private const string ECHO_ENGINE3_ID = "e00000000000000000000003";
     private const string SMT_ENGINE1_ID = "be0000000000000000000001";
     private const string NMT_ENGINE1_ID = "ce0000000000000000000001";
-    private const string FILE1_ID = "f00000000000000000000001";
+    private const string FILE1_SRC_ID = "f00000000000000000000001";
     private const string FILE1_FILENAME = "file_a";
-    private const string FILE2_ID = "f00000000000000000000002";
+    private const string FILE2_TRG_ID = "f00000000000000000000002";
     private const string FILE2_FILENAME = "file_b";
-    private const string FILE3_ID = "f00000000000000000000003";
+    private const string FILE3_SRC_ZIP_ID = "f00000000000000000000003";
     private const string FILE3_FILENAME = "file_c";
-    private const string FILE4_ID = "f00000000000000000000004";
+    private const string FILE4_TRG_ZIP_ID = "f00000000000000000000004";
     private const string FILE4_FILENAME = "file_d";
     private const string SOURCE_CORPUS_ID_1 = "cc0000000000000000000001";
     private const string SOURCE_CORPUS_ID_2 = "cc0000000000000000000002";
@@ -147,7 +147,7 @@ public class TranslationEngineTests
 
         var srcFile = new DataFiles.Models.DataFile
         {
-            Id = FILE1_ID,
+            Id = FILE1_SRC_ID,
             Owner = "client1",
             Name = "src.txt",
             Filename = FILE1_FILENAME,
@@ -155,7 +155,7 @@ public class TranslationEngineTests
         };
         var trgFile = new DataFiles.Models.DataFile
         {
-            Id = FILE2_ID,
+            Id = FILE2_TRG_ID,
             Owner = "client1",
             Name = "trg.txt",
             Filename = FILE2_FILENAME,
@@ -163,7 +163,7 @@ public class TranslationEngineTests
         };
         var srcParatextFile = new DataFiles.Models.DataFile
         {
-            Id = FILE3_ID,
+            Id = FILE3_SRC_ZIP_ID,
             Owner = "client1",
             Name = "src.zip",
             Filename = FILE3_FILENAME,
@@ -171,7 +171,7 @@ public class TranslationEngineTests
         };
         var trgParatextFile = new DataFiles.Models.DataFile
         {
-            Id = FILE4_ID,
+            Id = FILE4_TRG_ZIP_ID,
             Owner = "client1",
             Name = "trg.zip",
             Filename = FILE4_FILENAME,
@@ -184,21 +184,21 @@ public class TranslationEngineTests
             Id = SOURCE_CORPUS_ID_1,
             Language = "en",
             Owner = "client1",
-            Files = [new() { File = srcFile, TextId = "all" }]
+            Files = [new() { FileId = srcFile.Id, TextId = "all" }]
         };
         var srcCorpus2 = new DataFiles.Models.Corpus
         {
             Id = SOURCE_CORPUS_ID_2,
             Language = "en",
             Owner = "client1",
-            Files = [new() { File = srcFile, TextId = "all" }]
+            Files = [new() { FileId = srcFile.Id, TextId = "all" }]
         };
         var trgCorpus = new DataFiles.Models.Corpus
         {
             Id = TARGET_CORPUS_ID,
             Language = "en",
             Owner = "client1",
-            Files = [new() { File = trgFile, TextId = "all" }]
+            Files = [new() { FileId = trgFile.Id, TextId = "all" }]
         };
         await _env.Corpora.InsertAllAsync([srcCorpus, srcCorpus2, trgCorpus]);
     }
@@ -594,8 +594,8 @@ public class TranslationEngineTests
                 Assert.Multiple(() =>
                 {
                     Assert.That(result.Name, Is.EqualTo("TestCorpus"));
-                    Assert.That(result.SourceFiles.First().File.Id, Is.EqualTo(FILE1_ID));
-                    Assert.That(result.TargetFiles.First().File.Id, Is.EqualTo(FILE2_ID));
+                    Assert.That(result.SourceFiles.First().File.Id, Is.EqualTo(FILE1_SRC_ID));
+                    Assert.That(result.TargetFiles.First().File.Id, Is.EqualTo(FILE2_TRG_ID));
                 });
                 Engine? engine = await _env.Engines.GetAsync(engineId);
                 Assert.That(engine, Is.Not.Null);
@@ -651,11 +651,11 @@ public class TranslationEngineTests
                 TranslationCorpus result = await client.AddCorpusAsync(engineId, TestCorpusConfig);
                 TranslationCorpusFileConfig[] src = new[]
                 {
-                    new TranslationCorpusFileConfig { FileId = FILE2_ID, TextId = "all" }
+                    new TranslationCorpusFileConfig { FileId = FILE2_TRG_ID, TextId = "all" }
                 };
                 TranslationCorpusFileConfig[] trg = new[]
                 {
-                    new TranslationCorpusFileConfig { FileId = FILE1_ID, TextId = "all" }
+                    new TranslationCorpusFileConfig { FileId = FILE1_SRC_ID, TextId = "all" }
                 };
                 var updateConfig = new TranslationCorpusUpdateConfig { SourceFiles = src, TargetFiles = trg };
                 await client.UpdateCorpusAsync(engineId, result.Id, updateConfig);
@@ -675,11 +675,11 @@ public class TranslationEngineTests
                 {
                     TranslationCorpusFileConfig[] src = new[]
                     {
-                        new TranslationCorpusFileConfig { FileId = FILE2_ID, TextId = "all" }
+                        new TranslationCorpusFileConfig { FileId = FILE2_TRG_ID, TextId = "all" }
                     };
                     TranslationCorpusFileConfig[] trg = new[]
                     {
-                        new TranslationCorpusFileConfig { FileId = FILE1_ID, TextId = "all" }
+                        new TranslationCorpusFileConfig { FileId = FILE1_SRC_ID, TextId = "all" }
                     };
                     var updateConfig = new TranslationCorpusUpdateConfig { SourceFiles = src, TargetFiles = trg };
                     await client.UpdateCorpusAsync(engineId, DOES_NOT_EXIST_CORPUS_ID, updateConfig);
@@ -2031,6 +2031,56 @@ public class TranslationEngineTests
         Assert.That(ex.StatusCode, Is.EqualTo(403));
     }
 
+    [Test]
+    public async Task DataFileUpdate_Propagated()
+    {
+        TranslationEnginesClient translationClient = _env.CreateTranslationEnginesClient();
+        DataFilesClient dataFilesClient = _env.CreateDataFilesClient();
+        CorporaClient corporaClient = _env.CreateCorporaClient();
+        await translationClient.AddCorpusAsync(ECHO_ENGINE1_ID, TestCorpusConfig);
+        await translationClient.AddParallelCorpusAsync(ECHO_ENGINE2_ID, TestParallelCorpusConfig);
+
+        // Get the original files
+        DataFile orgFileFromClient = await dataFilesClient.GetAsync(FILE1_SRC_ID);
+        DataFiles.Models.DataFile orgFileFromRepo = (await _env.DataFiles.GetAsync(FILE1_SRC_ID))!;
+        DataFiles.Models.Corpus orgCorpusFromRepo = (await _env.Corpora.GetAsync(TARGET_CORPUS_ID))!;
+        Assert.That(orgFileFromClient.Name, Is.EqualTo(orgFileFromRepo.Name));
+        Assert.That(orgCorpusFromRepo.Files[0].FileId, Is.EqualTo(FILE2_TRG_ID));
+
+        // Update the file
+        await dataFilesClient.UpdateAsync(
+            FILE1_SRC_ID,
+            new FileParameter(new MemoryStream(new byte[] { 1, 2, 3 }), "test.txt")
+        );
+        await corporaClient.UpdateAsync(
+            TARGET_CORPUS_ID,
+            [new CorpusFileConfig { FileId = FILE4_TRG_ZIP_ID, TextId = "all" }]
+        );
+
+        // Confirm the change is propagated everywhere
+        DataFiles.Models.DataFile newFileFromRepo = (await _env.DataFiles.GetAsync(FILE1_SRC_ID))!;
+        Assert.That(newFileFromRepo.Filename, Is.Not.EqualTo(orgFileFromRepo.Filename));
+
+        Engine newEngine1 = (await _env.Engines.GetAsync(ECHO_ENGINE1_ID))!;
+        Engine newEngine2 = (await _env.Engines.GetAsync(ECHO_ENGINE2_ID))!;
+
+        // Updated (legacy) Corpus file filename
+        Assert.That(newEngine1.Corpora[0].SourceFiles[0].Filename, Is.EqualTo(newFileFromRepo.Filename));
+        Assert.That(newEngine1.Corpora[0].TargetFiles[0].Filename, Is.EqualTo(FILE2_FILENAME));
+
+        // Updated parallel corpus file filename
+        Assert.That(
+            newEngine2.ParallelCorpora[0].SourceCorpora[0].Files[0].Filename,
+            Is.EqualTo(newFileFromRepo.Filename)
+        );
+
+        // Updated set of new corpus files
+        Assert.That(newEngine2.ParallelCorpora[0].TargetCorpora[0].Id, Is.EqualTo(TARGET_CORPUS_ID));
+        Assert.That(newEngine2.ParallelCorpora[0].TargetCorpora[0].Files[0].Id, Is.EqualTo(FILE4_TRG_ZIP_ID));
+        Assert.That(newEngine2.ParallelCorpora[0].TargetCorpora[0].Files[0].Filename, Is.EqualTo(FILE4_FILENAME));
+        Assert.That(newEngine2.ParallelCorpora[0].TargetCorpora[0].Files.Count, Is.EqualTo(1));
+    }
+
     [TearDown]
     public void TearDown()
     {
@@ -2235,13 +2285,13 @@ public class TranslationEngineTests
 
         public TranslationEnginesClient CreateTranslationEnginesClient(IEnumerable<string>? scope = null)
         {
-            scope ??= new[]
-            {
+            scope ??=
+            [
                 Scopes.CreateTranslationEngines,
                 Scopes.ReadTranslationEngines,
                 Scopes.UpdateTranslationEngines,
                 Scopes.DeleteTranslationEngines
-            };
+            ];
             HttpClient httpClient = Factory
                 .WithWebHostBuilder(builder =>
                 {
@@ -2265,13 +2315,13 @@ public class TranslationEngineTests
 
         public TranslationEngineTypesClient CreateTranslationEngineTypesClient(IEnumerable<string>? scope = null)
         {
-            scope ??= new[]
-            {
+            scope ??=
+            [
                 Scopes.CreateTranslationEngines,
                 Scopes.ReadTranslationEngines,
                 Scopes.UpdateTranslationEngines,
                 Scopes.DeleteTranslationEngines
-            };
+            ];
             HttpClient httpClient = Factory
                 .WithWebHostBuilder(builder =>
                 {
@@ -2298,6 +2348,32 @@ public class TranslationEngineTests
                 );
             httpClient.DefaultRequestHeaders.Add("Scope", string.Join(" ", scope));
             return new TranslationEngineTypesClient(httpClient);
+        }
+
+        public DataFilesClient CreateDataFilesClient()
+        {
+            IEnumerable<string> scope = [Scopes.DeleteFiles, Scopes.ReadFiles, Scopes.UpdateFiles, Scopes.CreateFiles];
+            HttpClient httpClient = Factory
+                .WithWebHostBuilder(builder =>
+                {
+                    builder.ConfigureTestServices(services =>
+                    {
+                        services.AddTransient(CreateFileSystem);
+                    });
+                })
+                .CreateClient();
+            if (scope is not null)
+                httpClient.DefaultRequestHeaders.Add("Scope", string.Join(" ", scope));
+            return new DataFilesClient(httpClient);
+        }
+
+        public CorporaClient CreateCorporaClient()
+        {
+            IEnumerable<string> scope = [Scopes.DeleteFiles, Scopes.ReadFiles, Scopes.UpdateFiles, Scopes.CreateFiles];
+            HttpClient httpClient = Factory.WithWebHostBuilder(_ => { }).CreateClient();
+            if (scope is not null)
+                httpClient.DefaultRequestHeaders.Add("Scope", string.Join(" ", scope));
+            return new CorporaClient(httpClient);
         }
 
         public void ResetDatabases()
@@ -2337,6 +2413,7 @@ public class TranslationEngineTests
                     target.EntryExists("MATTRG.SFM").Returns(false);
                     return target;
                 });
+            fileSystem.OpenWrite(Arg.Any<string>()).Returns(ci => new MemoryStream());
             return fileSystem;
         }
 


### PR DESCRIPTION
Resolves https://github.com/sillsdev/serval/issues/547
Sync corpora and data files in translation engine
Make DataFile Corpuses only have a link to the DataFile
Fix ParallelCorpus Delete CorpusFile
Use mongoDB strings directly for Mongo array filtering (hacky solution - need to fix later https://github.com/sillsdev/serval/issues/553).
Broken implementation for MemoryRepository - https://github.com/sillsdev/serval/issues/554

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/555)
<!-- Reviewable:end -->
