### PR TITLE
#527 autoscaler test

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -19,8 +19,8 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       ClearML_AccessKey: ${{ secrets.ClearML_AccessKey }}
       ClearML_SecretKey: ${{ secrets.ClearML_SecretKey }}
-      GPU_QUEUE: autoscaler
-      CPU_QUEUE: autoscaler.cpu_only
+      CLEARML_GPU_QUEUE: autoscaler
+      CLEARML_CPU_QUEUE: autoscaler.cpu_only
       SERVAL_HOST_URL: http://localhost
       SERVAL_AUTH_URL: https://sil-appbuilder.auth0.com
       # ASPNETCORE_ENVIRONMENT: Development

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -19,6 +19,8 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       ClearML_AccessKey: ${{ secrets.ClearML_AccessKey }}
       ClearML_SecretKey: ${{ secrets.ClearML_SecretKey }}
+      GPU_QUEUE: autoscaler
+      CPU_QUEUE: autoscaler.cpu_only
       SERVAL_HOST_URL: http://localhost
       SERVAL_AUTH_URL: https://sil-appbuilder.auth0.com
       # ASPNETCORE_ENVIRONMENT: Development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: dockerfile.development
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_ENVIRONMENT=Staging
       - ASPNETCORE_DeploymentVersion=docker-compose
       - Auth__Domain=sil-appbuilder.auth0.com
       - Auth__Audience=https://serval-api.org/
@@ -49,7 +49,7 @@ services:
       context: .
       dockerfile: dockerfile.development
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_ENVIRONMENT=Staging
       - ASPNETCORE_Kestrel__Endpoints__Http__Url=http://*:80
       - ASPNETCORE_Kestrel__EndpointDefaults__Protocols=Http2
       - ASPNETCORE_ConnectionStrings__TranslationPlatformApi=http://serval-api:81
@@ -81,7 +81,7 @@ services:
       dockerfile: dockerfile.development
 
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_ENVIRONMENT=Staging
       - ASPNETCORE_Kestrel__Endpoints__Https__Url=http://*:80
       - ASPNETCORE_Kestrel__EndpointDefaults__Protocols=Http2
       - ASPNETCORE_ConnectionStrings__Hangfire=mongodb://mongo:27017/machine_jobs?replicaSet=myRS
@@ -127,7 +127,7 @@ services:
       context: .
       dockerfile: dockerfile.development
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_ENVIRONMENT=Staging
       - ASPNETCORE_ConnectionStrings__Hangfire=mongodb://mongo:27017/machine_jobs?replicaSet=myRS
       - ASPNETCORE_ConnectionStrings__Mongo=mongodb://mongo:27017/machine?replicaSet=myRS
       - ASPNETCORE_ConnectionStrings__Serval=http://serval-api:81

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: dockerfile.development
     environment:
-      - ASPNETCORE_ENVIRONMENT=Staging
+      - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_DeploymentVersion=docker-compose
       - Auth__Domain=sil-appbuilder.auth0.com
       - Auth__Audience=https://serval-api.org/
@@ -49,7 +49,7 @@ services:
       context: .
       dockerfile: dockerfile.development
     environment:
-      - ASPNETCORE_ENVIRONMENT=Staging
+      - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_Kestrel__Endpoints__Http__Url=http://*:80
       - ASPNETCORE_Kestrel__EndpointDefaults__Protocols=Http2
       - ASPNETCORE_ConnectionStrings__TranslationPlatformApi=http://serval-api:81
@@ -81,7 +81,7 @@ services:
       dockerfile: dockerfile.development
 
     environment:
-      - ASPNETCORE_ENVIRONMENT=Staging
+      - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_Kestrel__Endpoints__Https__Url=http://*:80
       - ASPNETCORE_Kestrel__EndpointDefaults__Protocols=Http2
       - ASPNETCORE_ConnectionStrings__Hangfire=mongodb://mongo:27017/machine_jobs?replicaSet=myRS
@@ -127,7 +127,7 @@ services:
       context: .
       dockerfile: dockerfile.development
     environment:
-      - ASPNETCORE_ENVIRONMENT=Staging
+      - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_ConnectionStrings__Hangfire=mongodb://mongo:27017/machine_jobs?replicaSet=myRS
       - ASPNETCORE_ConnectionStrings__Mongo=mongodb://mongo:27017/machine?replicaSet=myRS
       - ASPNETCORE_ConnectionStrings__Serval=http://serval-api:81
@@ -137,9 +137,9 @@ services:
       - ClearML__Project=docker-compose
       - "ClearML__AccessKey=${ClearML_AccessKey:?access key needed}"
       - "ClearML__SecretKey=${ClearML_SecretKey:?secret key needed}"
-      - BuildJob__ClearML__0__Queue=lambert_24gb
+      - BuildJob__ClearML__0__Queue=${CLEARML_GPU_QUEUE:lambert_24gb}
       - BuildJob__ClearML__0__DockerImage=${MACHINE_PY_IMAGE:-ghcr.io/sillsdev/machine.py:latest}
-      - BuildJob__ClearML__1__Queue=lambert_24gb.cpu_only
+      - BuildJob__ClearML__1__Queue=${CLEARML_CPU_QUEUE:lambert_24gb.cpu_only}
       - BuildJob__ClearML__1__DockerImage=${MACHINE_PY_CPU_IMAGE:-ghcr.io/sillsdev/machine.py:latest.cpu_only}
       - SharedFile__Uri=s3://silnlp/docker-compose/
       - "SharedFile__S3AccessKeyId=${AWS_ACCESS_KEY_ID:?access key needed}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,9 +91,9 @@ services:
       - ClearML__Project=docker-compose
       - "ClearML__AccessKey=${ClearML_AccessKey:?access key needed}"
       - "ClearML__SecretKey=${ClearML_SecretKey:?secret key needed}"
-      - BuildJob__ClearML__0__Queue=lambert_24gb
+      - BuildJob__ClearML__0__Queue=${CLEARML_GPU_QUEUE:-lambert_24gb}
       - BuildJob__ClearML__0__DockerImage=${MACHINE_PY_IMAGE:-ghcr.io/sillsdev/machine.py:latest}
-      - BuildJob__ClearML__1__Queue=lambert_24gb.cpu_only
+      - BuildJob__ClearML__1__Queue=${CLEARML_CPU_QUEUE:-lambert_24gb.cpu_only}
       - BuildJob__ClearML__1__DockerImage=${MACHINE_PY_CPU_IMAGE:-ghcr.io/sillsdev/machine.py:latest.cpu_only}
       - SharedFile__Uri=s3://silnlp/docker-compose/
       - "SharedFile__S3AccessKeyId=${AWS_ACCESS_KEY_ID:?access key needed}"
@@ -137,9 +137,9 @@ services:
       - ClearML__Project=docker-compose
       - "ClearML__AccessKey=${ClearML_AccessKey:?access key needed}"
       - "ClearML__SecretKey=${ClearML_SecretKey:?secret key needed}"
-      - BuildJob__ClearML__0__Queue=${CLEARML_GPU_QUEUE:lambert_24gb}
+      - BuildJob__ClearML__0__Queue=${CLEARML_GPU_QUEUE:-lambert_24gb}
       - BuildJob__ClearML__0__DockerImage=${MACHINE_PY_IMAGE:-ghcr.io/sillsdev/machine.py:latest}
-      - BuildJob__ClearML__1__Queue=${CLEARML_CPU_QUEUE:lambert_24gb.cpu_only}
+      - BuildJob__ClearML__1__Queue=${CLEARML_CPU_QUEUE:-lambert_24gb.cpu_only}
       - BuildJob__ClearML__1__DockerImage=${MACHINE_PY_CPU_IMAGE:-ghcr.io/sillsdev/machine.py:latest.cpu_only}
       - SharedFile__Uri=s3://silnlp/docker-compose/
       - "SharedFile__S3AccessKeyId=${AWS_ACCESS_KEY_ID:?access key needed}"


### PR DESCRIPTION
This PR moves the E2E tests to the autoscaler. The testing step took 22m 43s (24m 51s total), compared to 10m 4s (12m 0s total) if not using the autoscaler. Initial startup time is really only a factor for the first NMT job and the first SMT job, since the autoscaler can reuse instances.

Also, the reason the environment variables I added have `CLEARML` in all caps was to distinguish that they're not an official environment variable from ClearML, which uses `ClearML` to prepend its own environment variables. But I can change the environment variable names to match or to something else entirely if that's preferable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/563)
<!-- Reviewable:end -->
