### PR TITLE
update to 8.0 for e2e tests

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       - name: Start containers
         run:  dotnet build && docker compose -f "docker-compose.yml" up -d && sleep 20 #allow time for mongo to start up properly

--- a/src/Machine/src/Serval.Machine.Shared/Configuration/MessageOutboxOptions.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Configuration/MessageOutboxOptions.cs
@@ -6,4 +6,14 @@ public class MessageOutboxOptions
 
     public string OutboxDir { get; set; } = "outbox";
     public TimeSpan MessageExpirationTimeout { get; set; } = TimeSpan.FromHours(48);
+
+    public static JsonSerializerOptions JsonSerializerOptions
+    {
+        get
+        {
+            JsonSerializerOptions options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            options.AddProtobufSupport();
+            return options;
+        }
+    }
 }

--- a/src/Machine/src/Serval.Machine.Shared/Serval.Machine.Shared.csproj
+++ b/src/Machine/src/Serval.Machine.Shared/Serval.Machine.Shared.csproj
@@ -36,6 +36,7 @@
 		<PackageReference Include="Hangfire.Mongo" Version="1.10.8" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
+		<PackageReference Include="Protobuf.System.Text.Json" Version="1.4.0" />
 		<PackageReference Include="SIL.Machine" Version="3.5.2" Condition="!Exists('..\..\..\..\..\machine\src\SIL.Machine\SIL.Machine.csproj')" />
 		<PackageReference Include="SIL.Machine.Morphology.HermitCrab" Version="3.5.2" Condition="!Exists('..\..\..\..\..\machine\src\SIL.Machine.Morphology.HermitCrab\SIL.Machine.Morphology.HermitCrab.csproj')" />
 		<PackageReference Include="SIL.Machine.Translation.Thot" Version="3.5.2" Condition="!Exists('..\..\..\..\..\machine\src\SIL.Machine.Translation.Thot\SIL.Machine.Translation.Thot.csproj')" />

--- a/src/Machine/src/Serval.Machine.Shared/Services/IMessageOutboxService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/IMessageOutboxService.cs
@@ -2,12 +2,19 @@
 
 public interface IMessageOutboxService
 {
-    public Task<string> EnqueueMessageAsync(
+    public Task<string> EnqueueMessageAsync<TValue>(
         string outboxId,
         string method,
         string groupId,
-        string? content = null,
-        Stream? contentStream = null,
+        TValue content,
+        CancellationToken cancellationToken = default
+    );
+
+    public Task<string> EnqueueMessageStreamAsync(
+        string outboxId,
+        string method,
+        string groupId,
+        Stream contentStream,
         CancellationToken cancellationToken = default
     );
 }

--- a/src/Machine/src/Serval.Machine.Shared/Services/IOutboxMessageHandler.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/IOutboxMessageHandler.cs
@@ -5,6 +5,7 @@ public interface IOutboxMessageHandler
     public string OutboxId { get; }
 
     public Task HandleMessageAsync(
+        string groupId,
         string method,
         string? content,
         Stream? contentStream,

--- a/src/Machine/src/Serval.Machine.Shared/Services/MessageOutboxDeliveryService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/MessageOutboxDeliveryService.cs
@@ -58,7 +58,13 @@ public class MessageOutboxDeliveryService(
             {
                 try
                 {
-                    await ProcessGroupMessagesAsync(messages, message, outboxMessageHandler, cancellationToken);
+                    await ProcessGroupMessagesAsync(
+                        messages,
+                        message,
+                        messageGroup.Key.GroupId,
+                        outboxMessageHandler,
+                        cancellationToken
+                    );
                 }
                 catch (RpcException e)
                 {
@@ -98,6 +104,7 @@ public class MessageOutboxDeliveryService(
     private async Task ProcessGroupMessagesAsync(
         IRepository<OutboxMessage> messages,
         OutboxMessage message,
+        string groupId,
         IOutboxMessageHandler outboxMessageHandler,
         CancellationToken cancellationToken = default
     )
@@ -109,6 +116,7 @@ public class MessageOutboxDeliveryService(
         try
         {
             await outboxMessageHandler.HandleMessageAsync(
+                groupId,
                 message.Method,
                 message.Content,
                 contentStream,

--- a/src/Machine/src/Serval.Machine.Shared/Services/MessageOutboxService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/MessageOutboxService.cs
@@ -15,22 +15,20 @@ public class MessageOutboxService(
     private readonly IOptionsMonitor<MessageOutboxOptions> _options = options;
     internal int MaxDocumentSize { get; set; } = 1_000_000;
 
-    public async Task<string> EnqueueMessageAsync(
+    public async Task<string> EnqueueMessageAsync<TValue>(
         string outboxId,
         string method,
         string groupId,
-        string? content = null,
-        Stream? contentStream = null,
+        TValue content,
         CancellationToken cancellationToken = default
     )
     {
-        if (content == null && contentStream == null)
-            throw new ArgumentException("Either content or contentStream must be specified.");
-        if (content is not null && content.Length > MaxDocumentSize)
+        string serializedContent = JsonSerializer.Serialize(content, MessageOutboxOptions.JsonSerializerOptions);
+        if (serializedContent.Length > MaxDocumentSize)
         {
             throw new ArgumentException(
                 $"The content is too large for request {method} with group ID {groupId}. "
-                    + $"It is {content.Length} bytes, but the maximum is {MaxDocumentSize} bytes."
+                    + $"It is {serializedContent.Length} bytes, but the maximum is {MaxDocumentSize} bytes."
             );
         }
         Outbox outbox = (
@@ -49,24 +47,52 @@ public class MessageOutboxService(
                 OutboxRef = outboxId,
                 Method = method,
                 GroupId = groupId,
-                Content = content,
-                HasContentStream = contentStream is not null
+                Content = serializedContent,
+                HasContentStream = false
+            };
+        string filePath = Path.Combine(_options.CurrentValue.OutboxDir, outboxMessage.Id);
+        await _messages.InsertAsync(outboxMessage, cancellationToken: cancellationToken);
+        return outboxMessage.Id;
+    }
+
+    public async Task<string> EnqueueMessageStreamAsync(
+        string outboxId,
+        string method,
+        string groupId,
+        Stream contentStream,
+        CancellationToken cancellationToken = default
+    )
+    {
+        Outbox outbox = (
+            await _outboxes.UpdateAsync(
+                outboxId,
+                u => u.Inc(o => o.CurrentIndex, 1),
+                upsert: true,
+                cancellationToken: cancellationToken
+            )
+        )!;
+        OutboxMessage outboxMessage =
+            new()
+            {
+                Id = _idGenerator.GenerateId(),
+                Index = outbox.CurrentIndex,
+                OutboxRef = outboxId,
+                Method = method,
+                GroupId = groupId,
+                Content = null,
+                HasContentStream = true
             };
         string filePath = Path.Combine(_options.CurrentValue.OutboxDir, outboxMessage.Id);
         try
         {
-            if (contentStream is not null)
-            {
-                await using Stream fileStream = _fileSystem.OpenWrite(filePath);
-                await contentStream.CopyToAsync(fileStream, cancellationToken);
-            }
+            await using Stream fileStream = _fileSystem.OpenWrite(filePath);
+            await contentStream.CopyToAsync(fileStream, cancellationToken);
             await _messages.InsertAsync(outboxMessage, cancellationToken: cancellationToken);
             return outboxMessage.Id;
         }
         catch
         {
-            if (contentStream is not null)
-                _fileSystem.DeleteFile(filePath);
+            _fileSystem.DeleteFile(filePath);
             throw;
         }
     }

--- a/src/Machine/src/Serval.Machine.Shared/Services/ServalPlatformService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/ServalPlatformService.cs
@@ -16,7 +16,7 @@ public class ServalPlatformService(
             ServalPlatformOutboxConstants.OutboxId,
             ServalPlatformOutboxConstants.BuildStarted,
             buildId,
-            JsonSerializer.Serialize(new BuildStartedRequest { BuildId = buildId }),
+            new BuildStartedRequest { BuildId = buildId },
             cancellationToken: cancellationToken
         );
     }
@@ -32,14 +32,12 @@ public class ServalPlatformService(
             ServalPlatformOutboxConstants.OutboxId,
             ServalPlatformOutboxConstants.BuildCompleted,
             buildId,
-            JsonSerializer.Serialize(
-                new BuildCompletedRequest
-                {
-                    BuildId = buildId,
-                    CorpusSize = trainSize,
-                    Confidence = confidence
-                }
-            ),
+            new BuildCompletedRequest
+            {
+                BuildId = buildId,
+                CorpusSize = trainSize,
+                Confidence = confidence
+            },
             cancellationToken: cancellationToken
         );
     }
@@ -50,7 +48,7 @@ public class ServalPlatformService(
             ServalPlatformOutboxConstants.OutboxId,
             ServalPlatformOutboxConstants.BuildCanceled,
             buildId,
-            JsonSerializer.Serialize(new BuildCanceledRequest { BuildId = buildId }),
+            new BuildCanceledRequest { BuildId = buildId },
             cancellationToken: cancellationToken
         );
     }
@@ -61,7 +59,7 @@ public class ServalPlatformService(
             ServalPlatformOutboxConstants.OutboxId,
             ServalPlatformOutboxConstants.BuildFaulted,
             buildId,
-            JsonSerializer.Serialize(new BuildFaultedRequest { BuildId = buildId, Message = message }),
+            new BuildFaultedRequest { BuildId = buildId, Message = message },
             cancellationToken: cancellationToken
         );
     }
@@ -72,7 +70,7 @@ public class ServalPlatformService(
             ServalPlatformOutboxConstants.OutboxId,
             ServalPlatformOutboxConstants.BuildRestarting,
             buildId,
-            JsonSerializer.Serialize(new BuildRestartingRequest { BuildId = buildId }),
+            new BuildRestartingRequest { BuildId = buildId },
             cancellationToken: cancellationToken
         );
     }
@@ -111,13 +109,12 @@ public class ServalPlatformService(
         CancellationToken cancellationToken = default
     )
     {
-        await _outboxService.EnqueueMessageAsync(
+        await _outboxService.EnqueueMessageStreamAsync(
             ServalPlatformOutboxConstants.OutboxId,
             ServalPlatformOutboxConstants.InsertPretranslations,
             engineId,
-            engineId,
             pretranslationsStream,
-            cancellationToken: cancellationToken
+            cancellationToken
         );
     }
 
@@ -131,9 +128,7 @@ public class ServalPlatformService(
             ServalPlatformOutboxConstants.OutboxId,
             ServalPlatformOutboxConstants.IncrementTranslationEngineCorpusSize,
             engineId,
-            JsonSerializer.Serialize(
-                new IncrementTranslationEngineCorpusSizeRequest { EngineId = engineId, Count = count }
-            ),
+            new IncrementTranslationEngineCorpusSizeRequest { EngineId = engineId, Count = count },
             cancellationToken: cancellationToken
         );
     }
@@ -151,7 +146,7 @@ public class ServalPlatformService(
             ServalPlatformOutboxConstants.OutboxId,
             ServalPlatformOutboxConstants.UpdateBuildExecutionData,
             engineId,
-            JsonSerializer.Serialize(request),
+            request,
             cancellationToken: cancellationToken
         );
     }

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/MessageOutboxDeliveryServiceTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/MessageOutboxDeliveryServiceTests.cs
@@ -15,9 +15,9 @@ public class MessageOutboxDeliveryServiceTests
         await env.ProcessMessagesAsync();
         Received.InOrder(() =>
         {
-            env.Handler.HandleMessageAsync(Method2, "B", null, Arg.Any<CancellationToken>());
-            env.Handler.HandleMessageAsync(Method1, "A", null, Arg.Any<CancellationToken>());
-            env.Handler.HandleMessageAsync(Method2, "C", null, Arg.Any<CancellationToken>());
+            env.Handler.HandleMessageAsync(Arg.Any<string>(), Method2, "B", null, Arg.Any<CancellationToken>());
+            env.Handler.HandleMessageAsync(Arg.Any<string>(), Method1, "A", null, Arg.Any<CancellationToken>());
+            env.Handler.HandleMessageAsync(Arg.Any<string>(), Method2, "C", null, Arg.Any<CancellationToken>());
         });
         Assert.That(env.Messages.Count, Is.EqualTo(0));
     }
@@ -44,9 +44,21 @@ public class MessageOutboxDeliveryServiceTests
         await env.ProcessMessagesAsync();
         Assert.That(env.Messages.Count, Is.EqualTo(0));
         _ = env.Handler.Received(1)
-            .HandleMessageAsync(Method1, Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>());
+            .HandleMessageAsync(
+                Arg.Any<string>(),
+                Method1,
+                Arg.Any<string>(),
+                Arg.Any<Stream>(),
+                Arg.Any<CancellationToken>()
+            );
         _ = env.Handler.Received(4)
-            .HandleMessageAsync(Method2, Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>());
+            .HandleMessageAsync(
+                Arg.Any<string>(),
+                Method2,
+                Arg.Any<string>(),
+                Arg.Any<Stream>(),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     [Test]
@@ -62,7 +74,13 @@ public class MessageOutboxDeliveryServiceTests
         Assert.That(env.Messages.Get("A").Attempts, Is.EqualTo(0));
         Assert.That(env.Messages.Get("C").Attempts, Is.EqualTo(0));
         _ = env.Handler.Received(1)
-            .HandleMessageAsync(Method2, Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>());
+            .HandleMessageAsync(
+                Arg.Any<string>(),
+                Method2,
+                Arg.Any<string>(),
+                Arg.Any<Stream>(),
+                Arg.Any<CancellationToken>()
+            );
 
         env.Handler.ClearReceivedCalls();
         env.EnableHandlerFailure(StatusCode.Internal);
@@ -71,16 +89,34 @@ public class MessageOutboxDeliveryServiceTests
         Assert.That(env.Messages.Get("A").Attempts, Is.EqualTo(0));
         Assert.That(env.Messages.Get("C").Attempts, Is.EqualTo(1));
         _ = env.Handler.Received(2)
-            .HandleMessageAsync(Method2, Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>());
+            .HandleMessageAsync(
+                Arg.Any<string>(),
+                Method2,
+                Arg.Any<string>(),
+                Arg.Any<Stream>(),
+                Arg.Any<CancellationToken>()
+            );
 
         env.Handler.ClearReceivedCalls();
         env.DisableHandlerFailure();
         await env.ProcessMessagesAsync();
         Assert.That(env.Messages.Count, Is.EqualTo(0));
         _ = env.Handler.Received(1)
-            .HandleMessageAsync(Method1, Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>());
+            .HandleMessageAsync(
+                Arg.Any<string>(),
+                Method1,
+                Arg.Any<string>(),
+                Arg.Any<Stream>(),
+                Arg.Any<CancellationToken>()
+            );
         _ = env.Handler.Received(2)
-            .HandleMessageAsync(Method2, Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>());
+            .HandleMessageAsync(
+                Arg.Any<string>(),
+                Method2,
+                Arg.Any<string>(),
+                Arg.Any<Stream>(),
+                Arg.Any<CancellationToken>()
+            );
     }
 
     [Test]
@@ -92,7 +128,13 @@ public class MessageOutboxDeliveryServiceTests
         await env.ProcessMessagesAsync();
         Assert.That(env.Messages.Count, Is.EqualTo(0));
         _ = env.Handler.Received(1)
-            .HandleMessageAsync(Method1, "A", Arg.Is<Stream?>(s => s != null), Arg.Any<CancellationToken>());
+            .HandleMessageAsync(
+                Arg.Any<string>(),
+                Method1,
+                "A",
+                Arg.Is<Stream?>(s => s != null),
+                Arg.Any<CancellationToken>()
+            );
         env.FileSystem.Received().DeleteFile(Path.Combine("outbox", "A"));
     }
 
@@ -194,20 +236,44 @@ public class MessageOutboxDeliveryServiceTests
         public void EnableHandlerFailure(StatusCode code)
         {
             Handler
-                .HandleMessageAsync(Method1, Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+                .HandleMessageAsync(
+                    Arg.Any<string>(),
+                    Method1,
+                    Arg.Any<string>(),
+                    Arg.Any<Stream>(),
+                    Arg.Any<CancellationToken>()
+                )
                 .ThrowsAsync(new RpcException(new Status(code, "")));
             Handler
-                .HandleMessageAsync(Method2, Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+                .HandleMessageAsync(
+                    Arg.Any<string>(),
+                    Method2,
+                    Arg.Any<string>(),
+                    Arg.Any<Stream>(),
+                    Arg.Any<CancellationToken>()
+                )
                 .ThrowsAsync(new RpcException(new Status(code, "")));
         }
 
         public void DisableHandlerFailure()
         {
             Handler
-                .HandleMessageAsync(Method1, Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+                .HandleMessageAsync(
+                    Arg.Any<string>(),
+                    Method1,
+                    Arg.Any<string>(),
+                    Arg.Any<Stream>(),
+                    Arg.Any<CancellationToken>()
+                )
                 .Returns(Task.CompletedTask);
             Handler
-                .HandleMessageAsync(Method2, Arg.Any<string>(), Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+                .HandleMessageAsync(
+                    Arg.Any<string>(),
+                    Method2,
+                    Arg.Any<string>(),
+                    Arg.Any<Stream>(),
+                    Arg.Any<CancellationToken>()
+                )
                 .Returns(Task.CompletedTask);
         }
     }

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/MessageOutboxServiceTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/MessageOutboxServiceTests.cs
@@ -20,7 +20,7 @@ public class MessageOutboxServiceTests
         Assert.That(message.OutboxRef, Is.EqualTo(OutboxId));
         Assert.That(message.Method, Is.EqualTo(Method));
         Assert.That(message.Index, Is.EqualTo(1));
-        Assert.That(message.Content, Is.EqualTo("content"));
+        Assert.That(message.Content, Is.EqualTo("\"content\""));
         Assert.That(message.HasContentStream, Is.False);
     }
 
@@ -39,7 +39,7 @@ public class MessageOutboxServiceTests
         Assert.That(message.OutboxRef, Is.EqualTo(OutboxId));
         Assert.That(message.Method, Is.EqualTo(Method));
         Assert.That(message.Index, Is.EqualTo(2));
-        Assert.That(message.Content, Is.EqualTo("content"));
+        Assert.That(message.Content, Is.EqualTo("\"content\""));
         Assert.That(message.HasContentStream, Is.False);
     }
 
@@ -51,13 +51,13 @@ public class MessageOutboxServiceTests
         env.FileSystem.OpenWrite(Path.Combine("outbox", "1")).Returns(fileStream);
 
         await using MemoryStream stream = new(Encoding.UTF8.GetBytes("content"));
-        await env.Service.EnqueueMessageAsync(OutboxId, Method, "A", "content", stream);
+        await env.Service.EnqueueMessageStreamAsync(OutboxId, Method, "A", stream);
 
         OutboxMessage message = env.Messages.Get("1");
         Assert.That(message.OutboxRef, Is.EqualTo(OutboxId));
         Assert.That(message.Method, Is.EqualTo(Method));
         Assert.That(message.Index, Is.EqualTo(1));
-        Assert.That(message.Content, Is.EqualTo("content"));
+        Assert.That(message.Content, Is.EqualTo(null));
         Assert.That(message.HasContentStream, Is.True);
         Assert.That(fileStream.ToArray(), Is.EqualTo(stream.ToArray()));
     }

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/ServalPlatformOutboxMessageHandlerTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/ServalPlatformOutboxMessageHandlerTests.cs
@@ -6,17 +6,18 @@ namespace Serval.Machine.Shared.Services;
 [TestFixture]
 public class ServalPlatformOutboxMessageHandlerTests
 {
-    private static readonly JsonSerializerOptions JsonSerializerOptions =
-        new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-
     [Test]
     public async Task HandleMessageAsync_BuildStarted()
     {
         TestEnvironment env = new();
 
         await env.Handler.HandleMessageAsync(
+            "groupId",
             ServalPlatformOutboxConstants.BuildStarted,
-            JsonSerializer.Serialize(new BuildStartedRequest { BuildId = "C" }),
+            JsonSerializer.Serialize(
+                new BuildStartedRequest { BuildId = "C" },
+                MessageOutboxOptions.JsonSerializerOptions
+            ),
             null
         );
 
@@ -27,6 +28,7 @@ public class ServalPlatformOutboxMessageHandlerTests
     public async Task HandleMessageAsync_InsertPretranslations()
     {
         TestEnvironment env = new();
+
         await using (MemoryStream stream = new())
         {
             await JsonSerializer.SerializeAsync(
@@ -41,10 +43,11 @@ public class ServalPlatformOutboxMessageHandlerTests
                         Translation = "translation"
                     }
                 },
-                JsonSerializerOptions
+                MessageOutboxOptions.JsonSerializerOptions
             );
             stream.Seek(0, SeekOrigin.Begin);
             await env.Handler.HandleMessageAsync(
+                "engine1",
                 ServalPlatformOutboxConstants.InsertPretranslations,
                 "engine1",
                 stream

--- a/src/Serval/test/Serval.E2ETests/ServalApiTests.cs
+++ b/src/Serval/test/Serval.E2ETests/ServalApiTests.cs
@@ -125,7 +125,7 @@ public class ServalApiTests
             true
         );
         _helperClient.TranslationBuildConfig.Pretranslate = [new() { CorpusId = cId2, TextIds = ["2JN.txt"] }];
-        await _helperClient.BuildEngineAsync(engineId);
+        string buildId = await _helperClient.BuildEngineAsync(engineId);
         await Task.Delay(1000);
         IList<Pretranslation> lTrans1 = await _helperClient.TranslationEnginesClient.GetAllPretranslationsAsync(
             engineId,
@@ -137,7 +137,7 @@ public class ServalApiTests
             cId2
         );
 
-        TranslationBuild build = await _helperClient.TranslationEnginesClient.GetCurrentBuildAsync(engineId);
+        TranslationBuild build = await _helperClient.TranslationEnginesClient.GetBuildAsync(engineId, buildId);
         Assert.That(build.ExecutionData, Is.Not.Null);
 
         var executionData = build.ExecutionData!;

--- a/src/Serval/test/Serval.E2ETests/ServalClientHelper.cs
+++ b/src/Serval/test/Serval.E2ETests/ServalClientHelper.cs
@@ -123,7 +123,7 @@ public class ServalClientHelper : IAsyncDisposable
         return await TranslationEnginesClient.StartBuildAsync(engineId, TranslationBuildConfig);
     }
 
-    public async Task BuildEngineAsync(string engineId)
+    public async Task<string> BuildEngineAsync(string engineId)
     {
         TranslationBuild newJob = await StartBuildAsync(engineId);
         int revision = newJob.Revision;
@@ -151,6 +151,7 @@ public class ServalClientHelper : IAsyncDisposable
                 await Task.Delay(500);
             }
         }
+        return newJob.Id;
     }
 
     public async Task CancelBuildAsync(string engineId, string buildId, int timeoutSeconds = 20)


### PR DESCRIPTION
These fixes are needed to get E2E tests working:
* Update e2e build image to dotnet 8.0
* Fixes for BuildSummary including:
  * Use Protobuf.System.Text.Json to properly format dictionaries: https://stackoverflow.com/questions/66300807/protobuf-map-unserialization-issue
    * Update outbox handling to deal with the new Json Options
  * Fix E2E test properly getting build info after build is complete


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/592)
<!-- Reviewable:end -->
