### PR TITLE
Added endpoint for updating engine languages

### DIFF
--- a/src/Serval/src/Serval.Client/Client.g.cs
+++ b/src/Serval/src/Serval.Client/Client.g.cs
@@ -2200,6 +2200,23 @@ namespace Serval.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
+        /// Update the source and/or target languages of a translation engine
+        /// </summary>
+        /// <remarks>
+        /// ## Sample request:
+        /// <br/>            
+        /// <br/>    {
+        /// <br/>      "sourceLanguage": "en",
+        /// <br/>      "targetLanguage": "en"
+        /// <br/>    }
+        /// </remarks>
+        /// <param name="id">The translation engine id</param>
+        /// <returns>The engine language was successfully updated.</returns>
+        /// <exception cref="ServalApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task UpdateLanguagesAsync(string id, UpdateLanguagesRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
         /// Translate a segment of text
         /// </summary>
         /// <param name="id">The translation engine id</param>
@@ -3021,6 +3038,118 @@ namespace Serval.Client
                         {
                             string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new ServalApiException("The engine does not exist and therefore cannot be deleted.", status_, responseText_, headers_, null);
+                        }
+                        else
+                        if (status_ == 503)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ServalApiException("A necessary service is currently unavailable. Check `/health` for more details.", status_, responseText_, headers_, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ServalApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Update the source and/or target languages of a translation engine
+        /// </summary>
+        /// <remarks>
+        /// ## Sample request:
+        /// <br/>            
+        /// <br/>    {
+        /// <br/>      "sourceLanguage": "en",
+        /// <br/>      "targetLanguage": "en"
+        /// <br/>    }
+        /// </remarks>
+        /// <param name="id">The translation engine id</param>
+        /// <returns>The engine language was successfully updated.</returns>
+        /// <exception cref="ServalApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task UpdateLanguagesAsync(string id, UpdateLanguagesRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (id == null)
+                throw new System.ArgumentNullException("id");
+
+            if (request == null)
+                throw new System.ArgumentNullException("request");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, JsonSerializerSettings);
+                    var content_ = new System.Net.Http.StringContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("PATCH");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder_.Append(_baseUrl);
+                    // Operation Path: "translation/engines/{id}"
+                    urlBuilder_.Append("translation/engines/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ServalApiException("The client is not authenticated.", status_, responseText_, headers_, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ServalApiException("The authenticated client cannot perform the operation or does not own the translation engine.", status_, responseText_, headers_, null);
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ServalApiException("The engine does not exist and therefore cannot be updated.", status_, responseText_, headers_, null);
                         }
                         else
                         if (status_ == 503)
@@ -7237,6 +7366,19 @@ namespace Serval.Client
         /// </summary>
         [Newtonsoft.Json.JsonProperty("isModelPersisted", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? IsModelPersisted { get; set; } = default!;
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.1.0.0 (NJsonSchema v11.0.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateLanguagesRequest
+    {
+        [Newtonsoft.Json.JsonProperty("sourceLanguage", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string SourceLanguage { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("targetLanguage", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string TargetLanguage { get; set; } = default!;
 
     }
 

--- a/src/Serval/src/Serval.Translation/Contracts/UpdateLanguagesRequestDto.cs
+++ b/src/Serval/src/Serval.Translation/Contracts/UpdateLanguagesRequestDto.cs
@@ -1,0 +1,8 @@
+namespace Serval.Translation.Contracts;
+
+public class UpdateLanguagesRequestDto
+{
+    public string SourceLanguage { get; set; } = string.Empty;
+
+    public string TargetLanguage { get; set; } = string.Empty;
+}

--- a/src/Serval/src/Serval.Translation/Controllers/TranslationEnginesController.cs
+++ b/src/Serval/src/Serval.Translation/Controllers/TranslationEnginesController.cs
@@ -160,6 +160,58 @@ public class TranslationEnginesController(
     }
 
     /// <summary>
+    /// Update the source and/or target languages of a translation engine
+    /// </summary>
+    /// <remarks>
+    /// ## Sample request:
+    ///
+    ///     {
+    ///       "sourceLanguage": "en",
+    ///       "targetLanguage": "en"
+    ///     }
+    ///
+    /// </remarks>
+    /// <param name="id">The translation engine id</param>
+    /// <param name="cancellationToken"></param>
+    /// <response code="200">The engine language was successfully updated.</response>
+    /// <response code="401">The client is not authenticated.</response>
+    /// <response code="403">The authenticated client cannot perform the operation or does not own the translation engine.</response>
+    /// <response code="404">The engine does not exist and therefore cannot be updated.</response>
+    /// <response code="503">A necessary service is currently unavailable. Check `/health` for more details.</response>
+    [Authorize(Scopes.UpdateTranslationEngines)]
+    [HttpPatch("{id}")]
+    [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult> UpdateLanguagesAsync(
+        [FromRoute] string id,
+        [FromBody] UpdateLanguagesRequestDto request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await AuthorizeAsync(id, cancellationToken);
+
+        if (
+            request is null
+            || (string.IsNullOrWhiteSpace(request.SourceLanguage) && string.IsNullOrWhiteSpace(request.TargetLanguage))
+        )
+        {
+            return BadRequest("sourceLanguage or targetLanguage is required.");
+        }
+
+        await _engineService.UpdateLanguagesAsync(
+            id,
+            request.SourceLanguage,
+            request.TargetLanguage,
+            cancellationToken
+        );
+
+        return Ok();
+    }
+
+    /// <summary>
     /// Translate a segment of text
     /// </summary>
     /// <param name="id">The translation engine id</param>

--- a/src/Serval/src/Serval.Translation/Models/Engine.cs
+++ b/src/Serval/src/Serval.Translation/Models/Engine.cs
@@ -5,8 +5,8 @@ public record Engine : IOwnedEntity, IInitializableEntity
     public string Id { get; set; } = "";
     public int Revision { get; set; } = 1;
     public string? Name { get; init; }
-    public required string SourceLanguage { get; init; }
-    public required string TargetLanguage { get; init; }
+    public required string SourceLanguage { get; set; }
+    public required string TargetLanguage { get; set; }
     public required string Type { get; init; }
     public required string Owner { get; init; }
     public IReadOnlyList<Corpus> Corpora { get; init; } = new List<Corpus>();

--- a/src/Serval/src/Serval.Translation/Services/EngineService.cs
+++ b/src/Serval/src/Serval.Translation/Services/EngineService.cs
@@ -195,6 +195,33 @@ public class EngineService(
         return engine;
     }
 
+    public async Task UpdateLanguagesAsync(
+        string engineId,
+        string sourceLanguage = "",
+        string targetLanguage = "",
+        CancellationToken cancellationToken = default
+    )
+    {
+        Engine? engine = await Entities.GetAsync(engineId, cancellationToken);
+        if (engine is null)
+            throw new EntityNotFoundException($"Could not find the Engine '{engineId}'.");
+
+        if (sourceLanguage == "")
+            sourceLanguage = engine.SourceLanguage;
+        if (targetLanguage == "")
+            targetLanguage = engine.TargetLanguage;
+
+        await Entities.UpdateAsync(
+            engine,
+            u =>
+            {
+                u.Set(e => e.SourceLanguage, sourceLanguage);
+                u.Set(e => e.TargetLanguage, targetLanguage);
+            },
+            cancellationToken: CancellationToken.None
+        );
+    }
+
     public override async Task DeleteAsync(string engineId, CancellationToken cancellationToken = default)
     {
         Engine? engine = await Entities.GetAsync(engineId, cancellationToken);

--- a/src/Serval/src/Serval.Translation/Services/IEngineService.cs
+++ b/src/Serval/src/Serval.Translation/Services/IEngineService.cs
@@ -6,6 +6,14 @@ public interface IEngineService
     Task<Engine> GetAsync(string engineId, CancellationToken cancellationToken = default);
 
     Task<Engine> CreateAsync(Engine engine, CancellationToken cancellationToken = default);
+
+    Task UpdateLanguagesAsync(
+        string engineId,
+        string sourceLanguage,
+        string targetLanguage,
+        CancellationToken cancellationToken = default
+    );
+
     Task DeleteAsync(string engineId, CancellationToken cancellationToken = default);
 
     Task<TranslationResult> TranslateAsync(

--- a/src/Serval/test/Serval.Translation.Tests/Services/EngineServiceTests.cs
+++ b/src/Serval/test/Serval.Translation.Tests/Services/EngineServiceTests.cs
@@ -1966,6 +1966,82 @@ public class EngineServiceTests
         Assert.That(corpus.TargetFiles, Has.Count.EqualTo(1));
     }
 
+    [Test]
+    public async Task UpdateLanguagesAsync_ShouldUpdateLanguages_WhenRequestIsValid()
+    {
+        var env = new TestEnvironment();
+        var engine = await env.CreateEngineWithTextFilesAsync();
+
+        var request = new UpdateLanguagesRequestDto { SourceLanguage = "en", TargetLanguage = "fr" };
+
+        await env.Service.UpdateLanguagesAsync(engine.Id, request.SourceLanguage, request.TargetLanguage);
+
+        engine = await env.Engines.GetAsync(engine.Id);
+
+        Assert.That(engine, Is.Not.Null);
+        Assert.That(engine.SourceLanguage, Is.Not.Null);
+        Assert.That(engine.SourceLanguage, Is.EqualTo("en"));
+        Assert.That(engine.TargetLanguage, Is.Not.Null);
+        Assert.That(engine.TargetLanguage, Is.EqualTo("fr"));
+    }
+
+    [Test]
+    public async Task UpdateLanguagesAsync_ShouldNotUpdateSourceLanguage_WhenSourceLanguageNotProvided()
+    {
+        var env = new TestEnvironment();
+        var engine = await env.CreateEngineWithTextFilesAsync();
+
+        var request = new UpdateLanguagesRequestDto { SourceLanguage = "", TargetLanguage = "fr" };
+
+        await env.Service.UpdateLanguagesAsync(engine.Id, request.SourceLanguage, request.TargetLanguage);
+
+        var updatedEngine = await env.Engines.GetAsync(engine.Id);
+
+        Assert.That(updatedEngine, Is.Not.Null);
+        Assert.That(updatedEngine.SourceLanguage, Is.Not.Null);
+        Assert.That(updatedEngine.SourceLanguage, Is.EqualTo(engine.SourceLanguage));
+        Assert.That(updatedEngine.TargetLanguage, Is.Not.Null);
+        Assert.That(updatedEngine.TargetLanguage, Is.EqualTo("fr"));
+    }
+
+    [Test]
+    public async Task UpdateLanguagesAsync_ShouldNotUpdateTargetLanguage_WhenTargetLanguageNotProvided()
+    {
+        var env = new TestEnvironment();
+        var engine = await env.CreateEngineWithTextFilesAsync();
+
+        var request = new UpdateLanguagesRequestDto { SourceLanguage = "en", TargetLanguage = "" };
+
+        await env.Service.UpdateLanguagesAsync(engine.Id, request.SourceLanguage, request.TargetLanguage);
+
+        var updatedEngine = await env.Engines.GetAsync(engine.Id);
+
+        Assert.That(updatedEngine, Is.Not.Null);
+        Assert.That(updatedEngine.SourceLanguage, Is.Not.Null);
+        Assert.That(updatedEngine.SourceLanguage, Is.EqualTo("en"));
+        Assert.That(updatedEngine.TargetLanguage, Is.Not.Null);
+        Assert.That(updatedEngine.TargetLanguage, Is.EqualTo(engine.TargetLanguage));
+    }
+
+    [Test]
+    public async Task UpdateLanguagesAsync_ShouldNotUpdate_WhenSourceAndTargetLanguagesNotProvided()
+    {
+        var env = new TestEnvironment();
+        var engine = await env.CreateEngineWithTextFilesAsync();
+
+        var request = new UpdateLanguagesRequestDto { SourceLanguage = "", TargetLanguage = "" };
+
+        await env.Service.UpdateLanguagesAsync(engine.Id, request.SourceLanguage, request.TargetLanguage);
+
+        var updatedEngine = await env.Engines.GetAsync(engine.Id);
+
+        Assert.That(updatedEngine, Is.Not.Null);
+        Assert.That(updatedEngine.SourceLanguage, Is.Not.Null);
+        Assert.That(updatedEngine.SourceLanguage, Is.EqualTo(engine.SourceLanguage));
+        Assert.That(updatedEngine.TargetLanguage, Is.Not.Null);
+        Assert.That(updatedEngine.TargetLanguage, Is.EqualTo(engine.TargetLanguage));
+    }
+
     private class TestEnvironment
     {
         public TestEnvironment()


### PR DESCRIPTION
Added an endpoint for updating the languages of an engine. The user can pass in the desired source language or target language to update to or both.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/624)
<!-- Reviewable:end -->
