### PR TITLE
Fixes for NmtQueueMultiple E2E Test

### DIFF
--- a/src/Serval/test/Serval.E2ETests/ServalApiTests.cs
+++ b/src/Serval/test/Serval.E2ETests/ServalApiTests.cs
@@ -259,9 +259,9 @@ public class ServalApiTests
                 TranslationBuild canceledBuild = await _helperClient.TranslationEnginesClient.CancelBuildAsync(
                     engineIds[i]
                 );
-                Assert.That(currentBuild, Is.EqualTo(canceledBuild));
+                Assert.That(currentBuild.Id, Is.EqualTo(canceledBuild.Id));
             }
-            catch { }
+            catch (ServalApiException ex) when (ex.StatusCode == 204) { }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/sillsdev/serval/issues/675
* Assert ids are equal
* Catch only 204s

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/683)
<!-- Reviewable:end -->
