### PR TITLE
Add `pes` langcode mapping

### DIFF
--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/LanguageTagServiceTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/LanguageTagServiceTests.cs
@@ -22,6 +22,7 @@ public class LanguageTagServiceTests
     [TestCase("cmn-Hant", "zho_Hant", Description = "MandarinChineseScript")]
     [TestCase("ms", "zsm_Latn", Description = "Macrolanguage")]
     [TestCase("arb", "arb_Arab", Description = "Arabic")]
+    [TestCase("pes", "pes_Arab", Description = "KoreanScriptCorrection")]
     [TestCase("eng", "eng_Latn", Description = "InsteadOfISO639_1")]
     [TestCase("eng-Latn", "eng_Latn", Description = "DashToUnderscore")]
     [TestCase("kor", "kor_Hang", Description = "KoreanScript")]

--- a/src/ServiceToolkit/src/SIL.ServiceToolkit/Utils/LanguageTagParser.cs
+++ b/src/ServiceToolkit/src/SIL.ServiceToolkit/Utils/LanguageTagParser.cs
@@ -10,7 +10,8 @@ public partial class LanguageTagParser
             { "lv", "lvs" },
             { "ne", "npi" },
             { "sw", "swh" },
-            { "cmn", "zh" }
+            { "cmn", "zh" },
+            { "pes", "fa-IR" }
         };
 
     private static readonly Dictionary<string, string> StandardScripts = new() { { "Kore", "Hang" } };


### PR DESCRIPTION
Fixes https://github.com/sillsdev/serval/issues/688