### PR TITLE
Update separate progress to use user properties instead of runtime

### DIFF
--- a/src/Machine/src/Serval.Machine.Shared/Models/ClearMLParamsItem.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Models/ClearMLParamsItem.cs
@@ -1,0 +1,10 @@
+﻿namespace Serval.Machine.Shared.Models;
+
+public record ClearMLParamsItem
+{
+    public string? Section { get; init; }
+    public string? Name { get; init; }
+    public string? Value { get; init; }
+    public string? Type { get; init; }
+    public string? Description { get; init; }
+}

--- a/src/Machine/src/Serval.Machine.Shared/Models/ClearMLTask.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Models/ClearMLTask.cs
@@ -29,6 +29,10 @@ public record ClearMLTask
         string,
         IReadOnlyDictionary<string, ClearMLMetricsEvent>
     > LastMetrics { get; init; }
+    public required IReadOnlyDictionary<
+        string,
+        IReadOnlyDictionary<string, ClearMLParamsItem>
+    > Hyperparams { get; init; }
 
     [JsonConverter(typeof(DictionaryStringStringConverter))]
     public required IReadOnlyDictionary<string, string> Runtime { get; init; }

--- a/src/Machine/src/Serval.Machine.Shared/Services/ClearMLService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/ClearMLService.cs
@@ -219,7 +219,8 @@ public class ClearMLService(
             "created",
             "active_duration",
             "last_metrics",
-            "runtime"
+            "runtime",
+            "hyperparams"
         );
         JsonObject? result = await CallAsync("tasks", "get_all_ex", body, cancellationToken);
         var tasks = (JsonArray?)result?["data"]?["tasks"];

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/ClearMLMonitorServiceTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/ClearMLMonitorServiceTests.cs
@@ -125,6 +125,7 @@ public class ClearMLMonitorServiceTests
         ClearMLTaskStatus status,
         DateTime created,
         Dictionary<string, string>? runtime = null,
+        Dictionary<string, IReadOnlyDictionary<string, ClearMLParamsItem>>? hyperParams = null,
         Dictionary<string, IReadOnlyDictionary<string, ClearMLMetricsEvent>>? lastMetrics = null,
         int lastIteration = 0,
         string? statusMessage = null,
@@ -138,6 +139,7 @@ public class ClearMLMonitorServiceTests
             Status = status,
             Created = created,
             Runtime = runtime ?? new Dictionary<string, string>(),
+            Hyperparams = hyperParams ?? new Dictionary<string, IReadOnlyDictionary<string, ClearMLParamsItem>>(),
             LastMetrics = lastMetrics ?? new Dictionary<string, IReadOnlyDictionary<string, ClearMLMetricsEvent>>(),
             LastIteration = lastIteration,
             StatusMessage = statusMessage,
@@ -181,10 +183,14 @@ public class ClearMLMonitorServiceTests
         TranslationEngine engine = CreateTestEngine(jobState: BuildJobState.Active);
         SetupBuildingEngines(engine);
 
-        Dictionary<string, string> runtimeInfo = new Dictionary<string, string>
+        var runtimeInfo = new Dictionary<string, string> { { "progress", "50" } };
+
+        var hyperParams = new Dictionary<string, IReadOnlyDictionary<string, ClearMLParamsItem>>
         {
-            { "progress", "50" },
-            { "message", "Training epoch 5/10" }
+            [ClearMLMonitorService.UserProperties] = new Dictionary<string, ClearMLParamsItem>
+            {
+                ["message"] = new ClearMLParamsItem { Name = "message", Value = "Training epoch 5/10" }
+            }
         };
 
         ClearMLTask task = CreateClearMLTask(
@@ -193,6 +199,7 @@ public class ClearMLMonitorServiceTests
             status: ClearMLTaskStatus.InProgress,
             created: DateTime.UtcNow,
             runtime: runtimeInfo,
+            hyperParams: hyperParams,
             lastIteration: 5
         );
 
@@ -232,14 +239,20 @@ public class ClearMLMonitorServiceTests
             }
         };
 
-        Dictionary<string, string> runtime = new Dictionary<string, string> { ["message"] = "Training complete" };
+        var hyperParams = new Dictionary<string, IReadOnlyDictionary<string, ClearMLParamsItem>>
+        {
+            [ClearMLMonitorService.UserProperties] = new Dictionary<string, ClearMLParamsItem>
+            {
+                ["message"] = new ClearMLParamsItem { Name = "message", Value = "Training complete" }
+            }
+        };
 
         ClearMLTask task = CreateClearMLTask(
             id: engine!.CurrentBuild!.JobId,
             name: engine.CurrentBuild.BuildId,
             status: ClearMLTaskStatus.Completed,
             created: DateTime.UtcNow,
-            runtime: runtime,
+            hyperParams: hyperParams,
             lastMetrics: lastMetrics,
             lastIteration: 100
         );


### PR DESCRIPTION
Companion PR to https://github.com/sillsdev/machine.py/pull/205. Refactors the separate progress implementation to use user properties instead of the runtime.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/714)
<!-- Reviewable:end -->
