### PR TITLE
Revert "Don't fault build when there's no data (#571)"

### DIFF
--- a/src/Machine/src/Serval.Machine.Shared/Services/PreprocessBuildJob.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/PreprocessBuildJob.cs
@@ -60,7 +60,7 @@ public abstract class PreprocessBuildJob<TEngine>(
 
         if (trainCount == 0 && (!sourceTagInBaseModel || !targetTagInBaseModel))
         {
-            throw new OperationCanceledException(
+            throw new InvalidOperationException(
                 $"At least one language code in build {buildId} is unknown to the base model, and the data specified for training was empty. Build canceled."
             );
         }

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/PreprocessBuildJobTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/PreprocessBuildJobTests.cs
@@ -258,7 +258,7 @@ public class PreprocessBuildJobTests
         using TestEnvironment env = new();
         ParallelCorpus corpus1 = TestEnvironment.TextFileCorpus(sourceLanguage: "xxx", targetLanguage: "zzz");
 
-        Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
         {
             await env.RunBuildJobAsync(corpus1, engineId: "engine2");
         });


### PR DESCRIPTION
This reverts commit 0cfd14502a9968b6577f6ad030e34049daa8167d.

Fixes #719

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/722)
<!-- Reviewable:end -->
