### PR TITLE
Update the API example to use Progress instead of PercentCompleted

### DIFF
--- a/samples/ApiExample/Program.cs
+++ b/samples/ApiExample/Program.cs
@@ -239,14 +239,10 @@ async Task CreatePreTranslationEngineAsync(CancellationToken cancellationToken)
                 cancellationToken
             );
             if (translationBuild.DateFinished is not null)
-            {
                 break;
-            }
 
             Console.SetCursorPosition(0, cursorTop);
-            Console.WriteLine(
-                $"{translationBuild.State}: {(translationBuild.PercentCompleted ?? 0) * 100}% completed...   "
-            );
+            Console.WriteLine($"{translationBuild.State}: {(translationBuild.Progress ?? 0) * 100}% completed...   ");
 
             // Wait 20 seconds
             cancellationToken.WaitHandle.WaitOne(millisecondsTimeout: 20000);


### PR DESCRIPTION
Noticed while running a test with the API example. PercentCompleted is deprecated in the latest version of Serval.Client

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/731)
<!-- Reviewable:end -->
