### PR TITLE
Use UnsafeRelaxedJsonEscaping when writing JSON objects to S3 to avoid misinterpretation downstream

### DIFF
--- a/src/Machine/src/Serval.Machine.Shared/Services/PreprocessBuildJob.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/PreprocessBuildJob.cs
@@ -18,6 +18,8 @@ public abstract class PreprocessBuildJob<TEngine>(
     )
     where TEngine : ITrainingEngine
 {
+    // Using UnsafeRelaxedJsonEscaping to avoid escaping surrogate pairs which can result in invalid UTF-8.
+    // This is safe since the data written by this writer is only read internally and only as UTF-8 encoded JSON.
     protected static readonly JsonWriterOptions InferenceWriterOptions =
         new() { Indented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
 

--- a/src/Machine/src/Serval.Machine.Shared/Services/SmtTransferTrainBuildJob.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/SmtTransferTrainBuildJob.cs
@@ -12,6 +12,8 @@ public class SmtTransferTrainBuildJob(
     ITransferEngineFactory transferEngineFactory
 ) : HangfireBuildJob<TranslationEngine>(platformService, engines, dataAccessContext, buildJobService, logger)
 {
+    // Using UnsafeRelaxedJsonEscaping to avoid escaping surrogate pairs which can result in invalid UTF-8.
+    // This is safe since the data written by this writer is only read internally and only as UTF-8 encoded JSON.
     private static readonly JsonWriterOptions PretranslateWriterOptions =
         new() { Indented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
     private static readonly JsonSerializerOptions JsonSerializerOptions =

--- a/src/Machine/src/Serval.Machine.Shared/Services/StatisticalTrainBuildJob.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/StatisticalTrainBuildJob.cs
@@ -10,6 +10,8 @@ public class StatisticalTrainBuildJob(
     IWordAlignmentModelFactory wordAlignmentModelFactory
 ) : HangfireBuildJob<WordAlignmentEngine>(platformService, engines, dataAccessContext, buildJobService, logger)
 {
+    // Using UnsafeRelaxedJsonEscaping to avoid escaping surrogate pairs which can result in invalid UTF-8.
+    // This is safe since the data written by this writer is only read internally and only as UTF-8 encoded JSON.
     private static readonly JsonWriterOptions WordAlignmentWriterOptions =
         new() { Indented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
     private static readonly JsonSerializerOptions JsonSerializerOptions =


### PR DESCRIPTION
Fixes https://github.com/sillsdev/machine.py/issues/219

Tested this manually to confirm because there wasn't a straightforward way to expand an existing test to cover this. If you'd like me to write a new test fixture to cover this, I can.

Also, I dug back further in the failed jobs on the db and found that this was failing before the release to 1.10 as well but only for @pmachapman's test project. 

See the discussion here for more details: https://github.com/sillsdev/machine.py/pull/221

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/744)
<!-- Reviewable:end -->
