### PR TITLE
Add word alignment to kubernetes deployment

### DIFF
--- a/deploy/qa-int-values.yaml
+++ b/deploy/qa-int-values.yaml
@@ -10,7 +10,7 @@ lokiTenent: nlp-tenant
 lokiUrl: http://loki-distributed-gateway.loki.svc.cluster.local
 servalImage: ghcr.io/sillsdev/serval:1.10.4
 ClearMLDockerImage: ghcr.io/sillsdev/machine.py:1.9.11
-ClearMLQueue: lambert_24gb
+ClearMLQueue: production
 MongoConnectionPrefix: qa_int_
 SharedFileLocation: s3://silnlp/int-qa/
 servalClaimSize: 6Gi

--- a/deploy/serval/templates/echo-deployment.yaml
+++ b/deploy/serval/templates/echo-deployment.yaml
@@ -32,6 +32,8 @@ spec:
               value: Http2
             - name: ASPNETCORE_ConnectionStrings__TranslationPlatformApi
               value: http://serval-api:81
+            - name: ASPNETCORE_ConnectionStrings__WordAlignmentPlatformApi
+              value: http://serval-api:81
           image: {{ .Values.servalImage}}
           imagePullPolicy: "Always"
           name: echo

--- a/deploy/serval/templates/serval-api-deployment.yaml
+++ b/deploy/serval/templates/serval-api-deployment.yaml
@@ -52,6 +52,14 @@ spec:
               value: Nmt
             - name: ASPNETCORE_Translation__Engines__2__Address
               value: http://machine-engine
+            - name: ASPNETCORE_WordAlignment__Engines__0__Type
+              value: EchoWordAlignment
+            - name: ASPNETCORE_WordAlignment__Engines__0__Address
+              value: http://echo
+            - name: ASPNETCORE_WordAlignment__Engines__1__Type
+              value: Statistical
+            - name: ASPNETCORE_WordAlignment__Engines__1__Address
+              value: http://machine-engine
           image: {{ .Values.servalImage}}
           imagePullPolicy: "Always"
           name: serval-api


### PR DESCRIPTION
Fixes https://github.com/sillsdev/serval/issues/684
* Test on int-qa
* Also, use production queue for int-qa instead of lambert_24gb which is not reliable

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/750)
<!-- Reviewable:end -->
