### PR TITLE
Increase machine-job memory limit

### DIFF
--- a/deploy/serval/templates/machine-job-deployment.yaml
+++ b/deploy/serval/templates/machine-job-deployment.yaml
@@ -45,10 +45,10 @@ spec:
             - containerPort: 80
           resources:
             limits:
-              memory: "2500Mi"
+              memory: "3500Mi"
               cpu: "1.9"
             requests:
-              memory: "2500Mi"
+              memory: "3500Mi"
               cpu: "1.9"
           volumeMounts:
             - mountPath: /var/lib/machine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - 80:80
     depends_on:
       - mongo
+    mem_limit: 400M
     volumes:
       - .:/app:ro
       - ~/.nuget/packages:/root/.nuget/packages:ro
@@ -114,6 +115,7 @@ services:
     depends_on:
       - mongo
       - serval-api
+    mem_limit: 4500M
     volumes:
       - .:/app:ro
       - ~/.nuget/packages:/root/.nuget/packages:ro
@@ -163,6 +165,7 @@ services:
       - mongo
       - machine-engine
       - serval-api
+    mem_limit: 2500M
     volumes:
       - .:/app:ro
       - ~/.nuget/packages:/root/.nuget/packages:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,7 +165,7 @@ services:
       - mongo
       - machine-engine
       - serval-api
-    mem_limit: 2500M
+    mem_limit: 3500M
     volumes:
       - .:/app:ro
       - ~/.nuget/packages:/root/.nuget/packages:ro


### PR DESCRIPTION
This PR:
 - [Enforces the Kubernetes memory limits on the Docker images](https://github.com/sillsdev/serval/commit/052f962fcbe4c94e9b6aa799a072e57ff3df3f43)
 - [Increases machine-job memory limit to 3.5GB](https://github.com/sillsdev/serval/commit/a0969bf8ca18741ea7e20c0f13508ce6b0c009cb)

While testing using the docker image, I had two very large SMT jobs finish at approximately the same time, which resulted in the memory spiking:

<img width="808" height="372" alt="Screenshot 2025-09-10 093459" src="https://github.com/user-attachments/assets/60d02f6d-1d30-43e6-89fb-235e22db75fc" />

And one of the Hangfire jobs OOM'ing:

<img width="796" height="509" alt="Screenshot 2025-09-10 100751" src="https://github.com/user-attachments/assets/52f98ce2-034b-488b-b865-970743f57a61" />

It was not OOM killed by Docker as dotnet threw the exception before the OOM killer could kill it. This does make me think that there is a subtlety different configuration on the Kubernetes cluster (perhaps it is cgroups related?), but at the very least, it appears that the 2.5GB memory limit for machine-job is insufficient, so this PR increases the memory limit to 3.5GB, and enforces the limits in docker so we can potentially reproduce any OOM issues locally in future.