### PR TITLE
Fix GetNmtCancelAndRestartBuild e2e test & add model persisted test

### DIFF
--- a/src/Serval/test/Serval.E2ETests/ServalApiTests.cs
+++ b/src/Serval/test/Serval.E2ETests/ServalApiTests.cs
@@ -301,10 +301,12 @@ public class ServalApiTests
     {
         string engineId = await _helperClient.CreateNewEngineAsync("Nmt", "es", "en", "NMT2");
         TranslationEngine engine = await _helperClient.TranslationEnginesClient.GetAsync(engineId);
-        // NMT engines auto-fill IsModelPersisted as true
+        // NMT engines auto-fill IsModelPersisted as false
         Assert.That(engine.IsModelPersisted, Is.False);
         string[] books = ["1JN.txt", "2JN.txt", "3JN.txt"];
-        await _helperClient.AddTextCorpusToEngineAsync(engineId, books, "es", "en", false);
+        string corpusId = await _helperClient.AddTextCorpusToEngineAsync(engineId, books, "es", "en", false);
+        _helperClient.TranslationBuildConfig.TrainOn = [new() { CorpusId = corpusId, TextIds = ["1JN.txt"] }];
+        _helperClient.TranslationBuildConfig.Pretranslate = [new() { CorpusId = corpusId, TextIds = ["2JN.txt"] }];
         await StartAndCancelTwice(engineId);
     }
 


### PR DESCRIPTION
This PR fixes the e2e test that was failing because there was no data to inference, and I included a test to also run with the model persisted, which does not have the requirement for data to inference.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/759)
<!-- Reviewable:end -->
