### PR TITLE
Add `CanDenormalizeQuotes` migrator

### DIFF
--- a/src/Serval/src/Serval.Shared/Models/ParallelCorpusAnalysis.cs
+++ b/src/Serval/src/Serval.Shared/Models/ParallelCorpusAnalysis.cs
@@ -4,5 +4,4 @@ public record ParallelCorpusAnalysis
 {
     public required string ParallelCorpusRef { get; init; }
     public required string TargetQuoteConvention { get; init; }
-    public bool CanDenormalizeQuotes { get; init; }
 }

--- a/src/Serval/src/Serval.Translation/Configuration/IMongoDataAccessConfiguratorExtensions.cs
+++ b/src/Serval/src/Serval.Translation/Configuration/IMongoDataAccessConfiguratorExtensions.cs
@@ -51,18 +51,6 @@ public static class IMongoDataAccessConfiguratorExtensions
                     ),
                     new BsonDocument("$rename", new BsonDocument("percentCompleted", "progress"))
                 );
-                // migrate by adding canDenormalizeQuotes field
-                await c.UpdateManyAsync(
-                    Builders<Build>.Filter.And(
-                        Builders<Build>.Filter.Exists(b => b.Analysis, true),
-                        Builders<Build>.Filter.Ne(b => b.Analysis, null),
-                        Builders<Build>.Filter.ElemMatch(
-                            b => b.Analysis,
-                            Builders<ParallelCorpusAnalysis>.Filter.Exists(a => a.CanDenormalizeQuotes, false)
-                        )
-                    ),
-                    Builders<Build>.Update.Set(b => b.Analysis!.AllElements().CanDenormalizeQuotes, false)
-                );
             }
         );
         configurator.AddRepository<Pretranslation>(

--- a/src/Serval/src/Serval.Translation/Controllers/TranslationEnginesController.cs
+++ b/src/Serval/src/Serval.Translation/Controllers/TranslationEnginesController.cs
@@ -2166,7 +2166,7 @@ public class TranslationEnginesController(
             ParallelCorpusRef = source.ParallelCorpusRef,
             TargetQuoteConvention = source.TargetQuoteConvention,
             SourceQuoteConvention = "ignore",
-            CanDenormalizeQuotes = source.CanDenormalizeQuotes
+            CanDenormalizeQuotes = source.TargetQuoteConvention != ""
         };
     }
 }

--- a/src/Serval/src/Serval.Translation/Services/PretranslationService.cs
+++ b/src/Serval/src/Serval.Translation/Services/PretranslationService.cs
@@ -291,7 +291,7 @@ public class PretranslationService(
         if (
             quoteNormalizationBehavior == PretranslationNormalizationBehavior.Denormalized
             && build.Analysis is not null
-            && build.Analysis.Any(a => a.ParallelCorpusRef == corpusId && a.CanDenormalizeQuotes)
+            && build.Analysis.Any(a => a.ParallelCorpusRef == corpusId && a.TargetQuoteConvention != "")
         )
         {
             ParallelCorpusAnalysis analysis = build.Analysis.Single(c => c.ParallelCorpusRef == corpusId);

--- a/src/Serval/src/Serval.Translation/Services/TranslationPlatformServiceV1.cs
+++ b/src/Serval/src/Serval.Translation/Services/TranslationPlatformServiceV1.cs
@@ -307,8 +307,7 @@ public class TranslationPlatformServiceV1(
             .Select(a => new ParallelCorpusAnalysis
             {
                 ParallelCorpusRef = a.ParallelCorpusId,
-                TargetQuoteConvention = a.TargetQuoteConvention,
-                CanDenormalizeQuotes = a.TargetQuoteConvention != ""
+                TargetQuoteConvention = a.TargetQuoteConvention
             })
             .ToList();
         if (analysis.Count > 0)

--- a/src/Serval/test/Serval.Translation.Tests/Services/PlatformServiceTests.cs
+++ b/src/Serval/test/Serval.Translation.Tests/Services/PlatformServiceTests.cs
@@ -199,7 +199,6 @@ public class PlatformServiceTests
             {
                 ParallelCorpusRef = "parallelCorpus01",
                 TargetQuoteConvention = "typewriter_english",
-                CanDenormalizeQuotes = true
             },
         ];
 

--- a/src/Serval/test/Serval.Translation.Tests/Services/PretranslationServiceTests.cs
+++ b/src/Serval/test/Serval.Translation.Tests/Services/PretranslationServiceTests.cs
@@ -453,8 +453,7 @@ public class PretranslationServiceTests
                             new ParallelCorpusAnalysis()
                             {
                                 ParallelCorpusRef = "corpus1",
-                                TargetQuoteConvention = "standard_english",
-                                CanDenormalizeQuotes = true
+                                TargetQuoteConvention = "standard_english"
                             }
                         ]
                     },
@@ -468,8 +467,7 @@ public class PretranslationServiceTests
                             new ParallelCorpusAnalysis()
                             {
                                 ParallelCorpusRef = "parallel_corpus1",
-                                TargetQuoteConvention = "standard_english",
-                                CanDenormalizeQuotes = true
+                                TargetQuoteConvention = "standard_english"
                             }
                         ]
                     }


### PR DESCRIPTION
Fixes https://github.com/sillsdev/serval/issues/792

I went back and forth on whether to set them all to false or to update them depending on whether there was a target quote convention; let me know what you think. If we go for the latter, Peter, would you mind updating the migrator to do so? It wasn't clear to me how to get that to work in a way that's consistent with the Mongo API we're already using - I know you recently made some updates regarding array filtering as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/793)
<!-- Reviewable:end -->
