### PR TITLE
Ignore extra elements for all entities

### DIFF
--- a/src/DataAccess/src/SIL.DataAccess/IServiceCollectionExtensions.cs
+++ b/src/DataAccess/src/SIL.DataAccess/IServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class IServiceCollectionExtensions
             new StringIdStoredAsObjectIdConvention(),
             new CamelCaseElementNameConvention(),
             new EnumRepresentationConvention(BsonType.String),
+            new IgnoreExtraElementsConvention(true),
             new IgnoreIfNullConvention(true),
             new ObjectRefConvention()
         );

--- a/src/Machine/src/Serval.Machine.Shared/Configuration/IMachineBuilderExtensions.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Configuration/IMachineBuilderExtensions.cs
@@ -216,7 +216,6 @@ public static class IMachineBuilderExtensions
             {
                 o.AddRepository<TranslationEngine>(
                     "translation_engines",
-                    mapSetup: m => m.SetIgnoreExtraElements(true),
                     init: async c =>
                     {
                         await c.Indexes.CreateOrUpdateAsync(

--- a/src/Serval/src/Serval.Translation/Configuration/IMongoDataAccessConfiguratorExtensions.cs
+++ b/src/Serval/src/Serval.Translation/Configuration/IMongoDataAccessConfiguratorExtensions.cs
@@ -11,7 +11,6 @@ public static class IMongoDataAccessConfiguratorExtensions
     {
         configurator.AddRepository<Engine>(
             "translation.engines",
-            mapSetup: m => m.SetIgnoreExtraElements(true),
             init: async c =>
             {
                 await c.Indexes.CreateOrUpdateAsync(
@@ -29,7 +28,6 @@ public static class IMongoDataAccessConfiguratorExtensions
         );
         configurator.AddRepository<Build>(
             "translation.builds",
-            mapSetup: m => m.SetIgnoreExtraElements(true),
             init: static async c =>
             {
                 await c.Indexes.CreateOrUpdateAsync(

--- a/src/Serval/src/Serval.WordAlignment/Configuration/IMongoDataAccessConfiguratorExtensions.cs
+++ b/src/Serval/src/Serval.WordAlignment/Configuration/IMongoDataAccessConfiguratorExtensions.cs
@@ -11,7 +11,6 @@ public static class IMongoDataAccessConfiguratorExtensions
     {
         configurator.AddRepository<Engine>(
             "word_alignment.engines",
-            mapSetup: m => m.SetIgnoreExtraElements(true),
             init: async c =>
             {
                 await c.Indexes.CreateOrUpdateAsync(
@@ -24,7 +23,6 @@ public static class IMongoDataAccessConfiguratorExtensions
         );
         configurator.AddRepository<Build>(
             "word_alignment.builds",
-            mapSetup: m => m.SetIgnoreExtraElements(true),
             init: async c =>
             {
                 await c.Indexes.CreateOrUpdateAsync(


### PR DESCRIPTION
This PR sets IgnoreExtraElements as a global convention rather than via a class map.

When `SetIgnoreExtraElements(true)` is used in the class map, only that specific class being mapped will have extra elements ignored. Any child objects that contain extra elements will throw a `FormatException`, e.g.
```
System.FormatException: An error occurred while deserializing the Analysis property of class Serval.Translation.Models.Build: Element 'canDenormalizeQuotes' does not match any field or property of class Serval.Shared.Models.ParallelCorpusAnalysis.
 ---> System.FormatException: Element 'canDenormalizeQuotes' does not match any field or property of class Serval.Shared.Models.ParallelCorpusAnalysis.
   at MongoDB.Bson.Serialization.BsonClassMapSerializer`1.DeserializeClass(BsonDeserializationContext context)
   at MongoDB.Bson.Serialization.BsonClassMapSerializer`1.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
   at MongoDB.Bson.Serialization.IBsonSerializerExtensions.Deserialize[TValue](IBsonSerializer`1 serializer, BsonDeserializationContext context)
   at MongoDB.Bson.Serialization.Serializers.IEnumerableDeserializingAsCollectionSerializer`3.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
   at MongoDB.Bson.Serialization.Serializers.SerializerBase`1.MongoDB.Bson.Serialization.IBsonSerializer.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
   at MongoDB.Bson.Serialization.IBsonSerializerExtensions.Deserialize(IBsonSerializer serializer, BsonDeserializationContext context)
   at MongoDB.Bson.Serialization.BsonClassMapSerializer`1.DeserializeMemberValue(BsonDeserializationContext context, BsonMemberMap memberMap)
   --- End of inner exception stack trace ---
   at MongoDB.Bson.Serialization.BsonClassMapSerializer`1.DeserializeMemberValue(BsonDeserializationContext context, BsonMemberMap memberMap)
   at MongoDB.Bson.Serialization.BsonClassMapSerializer`1.DeserializeClass(BsonDeserializationContext context)
   at MongoDB.Bson.Serialization.BsonClassMapSerializer`1.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
   at MongoDB.Bson.Serialization.IBsonSerializerExtensions.Deserialize[TValue](IBsonSerializer`1 serializer, BsonDeserializationContext context)
   at MongoDB.Bson.Serialization.Serializers.EnumerableSerializerBase`2.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
   at MongoDB.Bson.Serialization.IBsonSerializerExtensions.Deserialize[TValue](IBsonSerializer`1 serializer, BsonDeserializationContext context)
   at MongoDB.Driver.Core.Operations.AggregateOperation`1.CursorDeserializer.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
   at MongoDB.Bson.Serialization.IBsonSerializerExtensions.Deserialize[TValue](IBsonSerializer`1 serializer, BsonDeserializationContext context)
   at MongoDB.Driver.Core.Operations.AggregateOperation`1.AggregateResultDeserializer.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
   at MongoDB.Bson.Serialization.IBsonSerializerExtensions.Deserialize[TValue](IBsonSerializer`1 serializer, BsonDeserializationContext context)
   at MongoDB.Driver.Core.WireProtocol.CommandUsingCommandMessageWireProtocol`1.ProcessResponse(ConnectionId connectionId, CommandMessage responseMessage)
   at MongoDB.Driver.Core.WireProtocol.CommandUsingCommandMessageWireProtocol`1.SendMessageAndProcessResponseAsync(CommandRequestMessage message, Int32 responseTo, IConnection connection, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.WireProtocol.CommandUsingCommandMessageWireProtocol`1.ExecuteAsync(IConnection connection, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Servers.Server.ServerChannel.ExecuteProtocolAsync[TResult](IWireProtocol`1 protocol, ICoreSession session, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Operations.RetryableReadOperationExecutor.ExecuteAsync[TResult](IRetryableReadOperation`1 operation, RetryableReadContext context, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Operations.ReadCommandOperation`1.ExecuteAsync(RetryableReadContext context, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Operations.AggregateOperation`1.ExecuteAsync(RetryableReadContext context, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Operations.AggregateOperation`1.ExecuteAsync(IReadBinding binding, CancellationToken cancellationToken)
   at MongoDB.Driver.OperationExecutor.ExecuteReadOperationAsync[TResult](IReadBinding binding, IReadOperation`1 operation, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1.ExecuteReadOperationAsync[TResult](IClientSessionHandle session, IReadOperation`1 operation, ReadPreference readPreference, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1.AggregateAsync[TResult](IClientSessionHandle session, PipelineDefinition`2 pipeline, AggregateOptions options, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1.UsingImplicitSessionAsync[TResult](Func`2 funcAsync, CancellationToken cancellationToken)
   at MongoDB.Driver.Linq.Linq3Implementation.Translators.ExpressionToExecutableQueryTranslators.ExecutableQuery`3.ExecuteAsync(IClientSessionHandle session, CancellationToken cancellationToken)
   at MongoDB.Driver.IAsyncCursorSourceExtensions.ToListAsync[TDocument](IAsyncCursorSource`1 source, CancellationToken cancellationToken)
   at SIL.DataAccess.MongoRepository`1.GetAllAsync(Expression`1 filter, CancellationToken cancellationToken) in /home/peter/source/serval/src/DataAccess/src/SIL.DataAccess/MongoRepository.cs:line 44
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/798)
<!-- Reviewable:end -->
