### PR TITLE
Update remark for paragraph breaks to match Scripture Forge

### DIFF
--- a/src/Serval/src/Serval.Translation/Services/PretranslationService.cs
+++ b/src/Serval/src/Serval.Translation/Services/PretranslationService.cs
@@ -351,13 +351,13 @@ public class PretranslationService(
     /// <para>Remarks are generated in the format:</para>
     /// <list type="bullet">
     /// <item><description>
-    /// Paragraph, embed and style markers were moved to the end of the verse.
+    /// Paragraph breaks, embed markers, and style markers were moved to the end of the verse.
     /// </description></item>
     /// <item><description>
-    /// Paragraph markers were moved to the end of the verse. Embed markers have positions preserved. Style markers were removed.
+    /// Paragraph breaks were moved to the end of the verse. Embed markers have positions preserved. Style markers were removed.
     /// </description></item>
     /// <item><description>
-    /// Paragraph and style markers were moved to the end of the verse. Embed markers were removed.
+    /// Paragraph breaks and style markers were moved to the end of the verse. Embed markers were removed.
     /// </description></item>
     /// </list>
     /// </remarks>
@@ -374,9 +374,9 @@ public class PretranslationService(
             { PretranslationUsfmMarkerBehavior.Strip, [] },
         };
 
-        behaviorMap[paragraphMarkerBehavior].Add("paragraph");
-        behaviorMap[embedBehavior].Add("embed");
-        behaviorMap[styleMarkerBehavior].Add("style");
+        behaviorMap[paragraphMarkerBehavior].Add("paragraph breaks");
+        behaviorMap[embedBehavior].Add("embed markers");
+        behaviorMap[styleMarkerBehavior].Add("style markers");
 
         IEnumerable<string> sentences = behaviorMap
             .Where(kvp => kvp.Value.Count > 0)
@@ -392,7 +392,7 @@ public class PretranslationService(
                     PretranslationUsfmMarkerBehavior.Strip => "were removed",
                     _ => "have unknown behavior",
                 };
-                return $"{markers} markers {behavior}.";
+                return $"{markers} {behavior}.";
             });
 
         return string.Join(" ", sentences);

--- a/src/Serval/test/Serval.ApiServer.IntegrationTests/TranslationEngineTests.cs
+++ b/src/Serval/test/Serval.ApiServer.IntegrationTests/TranslationEngineTests.cs
@@ -2195,7 +2195,7 @@ public class TranslationEngineTests
             Is.EqualTo(
                 @"\id MAT - TRG
 \rem This draft of MAT was generated using AI on 1970-01-01 00:00:00Z. It should be reviewed and edited carefully.
-\rem Paragraph and embed markers were moved to the end of the verse. Style markers were removed.
+\rem Paragraph breaks and embed markers were moved to the end of the verse. Style markers were removed.
 \h
 \c 1
 \p

--- a/src/Serval/test/Serval.Translation.Tests/Services/PretranslationServiceTests.cs
+++ b/src/Serval/test/Serval.Translation.Tests/Services/PretranslationServiceTests.cs
@@ -35,7 +35,7 @@ public class PretranslationServiceTests
             Is.EqualTo(
                     @"\id MAT - TRG
 \rem This draft of MAT was generated using AI on 1970-01-01 00:00:00Z. It should be reviewed and edited carefully.
-\rem Paragraph and embed markers were moved to the end of the verse. Style markers were removed.
+\rem Paragraph breaks and embed markers were moved to the end of the verse. Style markers were removed.
 \c 1
 \v 1 Chapter 1, verse 1. ""Translated new paragraph""
 \p
@@ -62,7 +62,7 @@ public class PretranslationServiceTests
             Is.EqualTo(
                     @"\id MAT - TRG
 \rem This draft of MAT was generated using AI on 1970-01-01 00:00:00Z. It should be reviewed and edited carefully.
-\rem Paragraph and embed markers were moved to the end of the verse. Style markers were removed.
+\rem Paragraph breaks and embed markers were moved to the end of the verse. Style markers were removed.
 \c 1
 \v 1 Chapter 1, verse 1. ""Translated new paragraph""
 \p
@@ -89,7 +89,7 @@ public class PretranslationServiceTests
             Is.EqualTo(
                     @"\id MAT - TRG
 \rem This draft of MAT was generated using AI on 1970-01-01 00:00:00Z. It should be reviewed and edited carefully.
-\rem Paragraph and embed markers were moved to the end of the verse. Style markers were removed.
+\rem Paragraph breaks and embed markers were moved to the end of the verse. Style markers were removed.
 \c 1
 \v 1
 \p
@@ -116,7 +116,7 @@ public class PretranslationServiceTests
             Is.EqualTo(
                     @"\id MAT - TRG
 \rem This draft of MAT was generated using AI on 1970-01-01 00:00:00Z. It should be reviewed and edited carefully.
-\rem Paragraph and embed markers were moved to the end of the verse. Style markers were removed.
+\rem Paragraph breaks and embed markers were moved to the end of the verse. Style markers were removed.
 \c 1
 \v 1 Chapter 1, verse 1. ""Translated new paragraph""
 \p
@@ -144,7 +144,7 @@ public class PretranslationServiceTests
             Is.EqualTo(
                     @"\id MAT - TRG
 \rem This draft of MAT was generated using AI on 1970-01-01 00:00:00Z. It should be reviewed and edited carefully.
-\rem Embed markers were moved to the end of the verse. Paragraph markers have positions preserved. Style markers were removed.
+\rem Embed markers were moved to the end of the verse. Paragraph breaks have positions preserved. Style markers were removed.
 \c 1
 \v 1 Chapter 1, verse 1.
 \p ""Translated new paragraph""
@@ -172,7 +172,7 @@ public class PretranslationServiceTests
             Is.EqualTo(
                     @"\id MAT - TRG
 \rem This draft of MAT was generated using AI on 1970-01-01 00:00:00Z. It should be reviewed and edited carefully.
-\rem Paragraph and embed markers were moved to the end of the verse. Style markers were removed.
+\rem Paragraph breaks and embed markers were moved to the end of the verse. Style markers were removed.
 \c 1
 \v 1 TRG - Chapter one, verse one.
 \v 2 Chapter 1, verse 2.
@@ -199,7 +199,7 @@ public class PretranslationServiceTests
             Is.EqualTo(
                     @"\id MAT - TRG
 \rem This draft of MAT was generated using AI on 1970-01-01 00:00:00Z. It should be reviewed and edited carefully.
-\rem Paragraph and embed markers were moved to the end of the verse. Style markers were removed.
+\rem Paragraph breaks and embed markers were moved to the end of the verse. Style markers were removed.
 \c 1
 \v 1 Chapter 1, verse 1. ""Translated new paragraph""
 \v 2 Chapter 1, verse 2.
@@ -238,7 +238,7 @@ public class PretranslationServiceTests
             Is.EqualTo(
                     @"\id MAT - TRG
 \rem This draft of MAT was generated using AI on 1970-01-01 00:00:00Z. It should be reviewed and edited carefully.
-\rem Paragraph and embed markers were moved to the end of the verse. Style markers were removed.
+\rem Paragraph breaks and embed markers were moved to the end of the verse. Style markers were removed.
 \c 1
 \v 1 Chapter 1, verse 1. ""Translated new paragraph""
 \p
@@ -266,7 +266,7 @@ public class PretranslationServiceTests
             Is.EqualTo(
                     @"\id MAT - TRG
 \rem This draft of MAT was generated using AI on 1970-01-01 00:00:00Z. It should be reviewed and edited carefully.
-\rem Paragraph and embed markers were moved to the end of the verse. Style markers were removed.
+\rem Paragraph breaks and embed markers were moved to the end of the verse. Style markers were removed.
 \c 1
 \v 1 Chapter 1, verse 1. ""Translated new paragraph""
 \v 2 Chapter 1, verse 2.
@@ -296,7 +296,7 @@ public class PretranslationServiceTests
         );
         lines.Insert(
             2,
-            @"\rem Paragraph and embed markers were moved to the end of the verse. Style markers were removed."
+            @"\rem Paragraph breaks and embed markers were moved to the end of the verse. Style markers were removed."
         );
         Assert.That(usfm, Is.EqualTo(string.Join('\n', lines)).IgnoreLineEndings());
     }
@@ -317,7 +317,7 @@ public class PretranslationServiceTests
             Is.EqualTo(
                     @"\id MAT - TRG
 \rem This draft of MAT was generated using AI on 1970-01-01 00:00:00Z. It should be reviewed and edited carefully.
-\rem Paragraph and embed markers were moved to the end of the verse. Style markers were removed.
+\rem Paragraph breaks and embed markers were moved to the end of the verse. Style markers were removed.
 \c 1
 \v 1 Chapter 1, verse 1. ""Translated new paragraph""
 \v 2 Chapter 1, verse 2.


### PR DESCRIPTION
This is what the Scripture Forge UI looks like

<img width="450" height="452" alt="localhost_5000_projects_68fa47e15227ca2998b1b953_draft-generation (1)" src="https://github.com/user-attachments/assets/c90a3b72-0222-4f08-b7dc-dbe5beecb263" />

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/809)
<!-- Reviewable:end -->
