### PR TITLE
Update remark for automatic quote style to match Scripture Forge

### DIFF
--- a/src/Serval/src/Serval.Translation/Services/PretranslationService.cs
+++ b/src/Serval/src/Serval.Translation/Services/PretranslationService.cs
@@ -321,7 +321,7 @@ public class PretranslationService(
         if (bestChapterStrategies.Any(s => s != QuotationMarkUpdateStrategy.Skip))
         {
             string quotationDenormalizationRemark =
-                "Quotation marks in the following chapters have been automatically denormalized after translation: "
+                "The quote style in the following chapters has been automatically adjusted to match the rest of the project: "
                 + string.Join(
                     ", ",
                     bestChapterStrategies


### PR DESCRIPTION
This is what the Scripture Forge UI looks like

<img width="450" height="263" alt="localhost_5000_projects_68fa47e15227ca2998b1b953_draft-generation (2)" src="https://github.com/user-attachments/assets/19765da0-b4a6-4198-adb8-8e1afbe7fe5e" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/810)
<!-- Reviewable:end -->
