### PR TITLE
Return a 400 error when TrainOn or Pretranslate have duplicate keys

### DIFF
--- a/src/Serval/src/Serval.Translation/Controllers/TranslationEnginesController.cs
+++ b/src/Serval/src/Serval.Translation/Controllers/TranslationEnginesController.cs
@@ -1686,6 +1686,22 @@ public class TranslationEnginesController(
         if (source is null)
             return null;
 
+        if (
+            source.Where(p => p.ParallelCorpusId != null).Select(p => p.ParallelCorpusId).Distinct().Count()
+            != source.Count(p => p.ParallelCorpusId != null)
+        )
+        {
+            throw new InvalidOperationException($"Each ParallelCorpusId may only be specified once.");
+        }
+
+        if (
+            source.Where(p => p.CorpusId != null).Select(p => p.CorpusId).Distinct().Count()
+            != source.Count(p => p.CorpusId != null)
+        )
+        {
+            throw new InvalidOperationException($"Each CorpusId may only be specified once.");
+        }
+
         var corpusIds = new HashSet<string>(engine.Corpora.Select(c => c.Id));
         var parallelCorpusIds = new HashSet<string>(engine.ParallelCorpora.Select(c => c.Id));
         var pretranslateCorpora = new List<PretranslateCorpus>();
@@ -1774,6 +1790,22 @@ public class TranslationEnginesController(
     {
         if (source is null)
             return null;
+
+        if (
+            source.Where(p => p.ParallelCorpusId != null).Select(p => p.ParallelCorpusId).Distinct().Count()
+            != source.Count(p => p.ParallelCorpusId != null)
+        )
+        {
+            throw new InvalidOperationException($"Each ParallelCorpusId may only be specified once.");
+        }
+
+        if (
+            source.Where(p => p.CorpusId != null).Select(p => p.CorpusId).Distinct().Count()
+            != source.Count(p => p.CorpusId != null)
+        )
+        {
+            throw new InvalidOperationException($"Each CorpusId may only be specified once.");
+        }
 
         var corpusIds = new HashSet<string>(engine.Corpora.Select(c => c.Id));
         var parallelCorpusIds = new HashSet<string>(engine.ParallelCorpora.Select(c => c.Id));

--- a/src/Serval/src/Serval.WordAlignment/Controllers/WordAlignmentEnginesController.cs
+++ b/src/Serval/src/Serval.WordAlignment/Controllers/WordAlignmentEnginesController.cs
@@ -796,13 +796,16 @@ public class WordAlignmentEnginesController(
         if (source is null)
             return null;
 
+        if (source.Select(p => p.ParallelCorpusId).Distinct().Count() != source.Count)
+            throw new InvalidOperationException("Each ParallelCorpusId may only be specified once.");
+
         var corpusIds = new HashSet<string>(engine.ParallelCorpora.Select(c => c.Id));
         var wordAlignmentCorpora = new List<WordAlignmentCorpus>();
         foreach (WordAlignmentCorpusConfigDto cc in source)
         {
             if (cc.ParallelCorpusId == null)
             {
-                throw new InvalidOperationException($"One of ParallelCorpusId and CorpusId must be set.");
+                throw new InvalidOperationException($"ParallelCorpusId must be set.");
             }
             if (!corpusIds.Contains(cc.ParallelCorpusId))
             {
@@ -847,6 +850,9 @@ public class WordAlignmentEnginesController(
     {
         if (source is null)
             return null;
+
+        if (source.Select(p => p.ParallelCorpusId).Distinct().Count() != source.Count)
+            throw new InvalidOperationException($"Each ParallelCorpusId may only be specified once.");
 
         var corpusIds = new HashSet<string>(engine.ParallelCorpora.Select(c => c.Id));
         var trainingCorpora = new List<TrainingCorpus>();


### PR DESCRIPTION
Fixes #295.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/819)
<!-- Reviewable:end -->
