### PR TITLE
Fix execution data warning serialization and deserialization bugs

### DIFF
--- a/src/Machine/src/Serval.Machine.Shared/Models/Build.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Models/Build.cs
@@ -29,5 +29,5 @@ public record Build
     public required BuildJobRunnerType BuildJobRunner { get; init; }
     public required BuildStage Stage { get; init; }
     public string? Options { get; set; }
-    public IReadOnlyDictionary<string, object> ExecutionData { get; init; } = new Dictionary<string, object>();
+    public required BuildExecutionData ExecutionData { get; init; }
 }

--- a/src/Machine/src/Serval.Machine.Shared/Models/BuildExecutionData.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Models/BuildExecutionData.cs
@@ -1,0 +1,13 @@
+namespace Serval.Machine.Shared.Models;
+
+public record BuildExecutionData
+{
+    public int? TrainCount { get; init; }
+    public int? PretranslateCount { get; init; }
+    public int? WordAlignCount { get; init; }
+    public IReadOnlyList<string>? Warnings { get; init; }
+    public string? EngineSourceLanguageTag { get; init; }
+    public string? EngineTargetLanguageTag { get; init; }
+    public string? ResolvedSourceLanguage { get; init; }
+    public string? ResolvedTargetLanguage { get; init; }
+}

--- a/src/Machine/src/Serval.Machine.Shared/Services/BuildJobService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/BuildJobService.cs
@@ -102,7 +102,8 @@ public class BuildJobService<TEngine>(IEnumerable<IBuildJobRunner> runners, IRep
                             BuildJobRunner = runner.Type,
                             Stage = stage,
                             JobState = BuildJobState.Pending,
-                            Options = buildOptions
+                            Options = buildOptions,
+                            ExecutionData = new BuildExecutionData()
                         }
                     ),
                 cancellationToken: cancellationToken

--- a/src/Machine/src/Serval.Machine.Shared/Services/IPlatformService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/IPlatformService.cs
@@ -33,7 +33,7 @@ public interface IPlatformService
     Task UpdateBuildExecutionDataAsync(
         string engineId,
         string buildId,
-        IReadOnlyDictionary<string, object> executionData,
+        BuildExecutionData executionData,
         CancellationToken cancellationToken = default
     );
 

--- a/src/Machine/src/Serval.Machine.Shared/Services/NmtPreprocessBuildJob.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/NmtPreprocessBuildJob.cs
@@ -103,15 +103,15 @@ public class NmtPreprocessBuildJob(
                 { "Warnings", new JsonArray(warnings.Select(w => JsonValue.Create(w)).ToArray()) }
             };
         Logger.LogInformation("{summary}", buildPreprocessSummary.ToJsonString());
-        var executionData = new Dictionary<string, object>()
+        var executionData = new BuildExecutionData()
         {
-            { "trainCount", trainCount },
-            { "pretranslateCount", pretranslateCount },
-            { "warnings", warnings },
-            { "engineSourceLanguageTag", sourceLanguageTag },
-            { "engineTargetLanguageTag", targetLanguageTag },
-            { "resolvedSourceLanguage", resolvedSourceLanguage },
-            { "resolvedTargetLanguage", resolvedTargetLanguage },
+            TrainCount = trainCount,
+            PretranslateCount = pretranslateCount,
+            Warnings = warnings,
+            EngineSourceLanguageTag = sourceLanguageTag,
+            EngineTargetLanguageTag = targetLanguageTag,
+            ResolvedSourceLanguage = resolvedSourceLanguage,
+            ResolvedTargetLanguage = resolvedTargetLanguage
         };
         await PlatformService.UpdateBuildExecutionDataAsync(engineId, buildId, executionData, cancellationToken);
     }

--- a/src/Machine/src/Serval.Machine.Shared/Services/ServalWordAlignmentPlatformService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/ServalWordAlignmentPlatformService.cs
@@ -149,7 +149,7 @@ public class ServalWordAlignmentPlatformService(
     public async Task UpdateBuildExecutionDataAsync(
         string engineId,
         string buildId,
-        IReadOnlyDictionary<string, object> executionData,
+        BuildExecutionData executionData,
         CancellationToken cancellationToken = default
     )
     {
@@ -157,28 +157,16 @@ public class ServalWordAlignmentPlatformService(
         {
             EngineId = engineId,
             BuildId = buildId,
-            ExecutionData = new Google.Protobuf.WellKnownTypes.Struct()
+            ExecutionData = new ExecutionData
+            {
+                TrainCount = executionData.TrainCount ?? 0,
+                WordAlignCount = executionData.WordAlignCount ?? 0,
+                EngineSourceLanguageTag = executionData.EngineSourceLanguageTag,
+                EngineTargetLanguageTag = executionData.EngineTargetLanguageTag,
+            }
         };
-        foreach (KeyValuePair<string, object> kvp in executionData)
-        {
-            var value = new Google.Protobuf.WellKnownTypes.Value();
-            if (kvp.Value is string stringValue)
-            {
-                value.StringValue = stringValue;
-            }
-            else if (kvp.Value is int numberValue)
-            {
-                value.NumberValue = numberValue;
-            }
-            else if (kvp.Value is List<string> listValue)
-            {
-                value.ListValue = new Google.Protobuf.WellKnownTypes.ListValue();
-                value.ListValue.Values.AddRange(
-                    listValue.Select(s => new Google.Protobuf.WellKnownTypes.Value() { StringValue = s })
-                );
-            }
-            request.ExecutionData.Fields.Add(kvp.Key, value);
-        }
+        foreach (string warning in executionData.Warnings ?? [])
+            request.ExecutionData.Warnings.Add(warning);
         await _outboxService.EnqueueMessageAsync(
             outboxId: ServalWordAlignmentPlatformOutboxConstants.OutboxId,
             method: ServalWordAlignmentPlatformOutboxConstants.UpdateBuildExecutionData,

--- a/src/Machine/src/Serval.Machine.Shared/Services/TranslationPreprocessBuildJob.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/TranslationPreprocessBuildJob.cs
@@ -115,13 +115,13 @@ public class TranslationPreprocessBuildJob(
                 { "Warnings", new JsonArray(warnings.Select(w => JsonValue.Create(w)).ToArray()) }
             };
         Logger.LogInformation("{summary}", buildPreprocessSummary.ToJsonString());
-        var executionData = new Dictionary<string, object>()
+        var executionData = new BuildExecutionData()
         {
-            { "trainCount", trainCount },
-            { "pretranslateCount", pretranslateCount },
-            { "warnings", warnings },
-            { "engineSourceLanguageTag", sourceLanguageTag },
-            { "engineTargetLanguageTag", targetLanguageTag },
+            TrainCount = trainCount,
+            PretranslateCount = pretranslateCount,
+            Warnings = warnings,
+            EngineSourceLanguageTag = sourceLanguageTag,
+            EngineTargetLanguageTag = targetLanguageTag
         };
         await PlatformService.UpdateBuildExecutionDataAsync(engineId, buildId, executionData, cancellationToken);
     }

--- a/src/Machine/src/Serval.Machine.Shared/Services/WordAlignmentPreprocessBuildJob.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/WordAlignmentPreprocessBuildJob.cs
@@ -115,13 +115,13 @@ public class WordAlignmentPreprocessBuildJob(
                 { "Warnings", new JsonArray(warnings.Select(w => JsonValue.Create(w)).ToArray()) }
             };
         Logger.LogInformation("{summary}", buildPreprocessSummary.ToJsonString());
-        var executionData = new Dictionary<string, object>()
+        var executionData = new BuildExecutionData()
         {
-            { "trainCount", trainCount },
-            { "wordAlignCount", wordAlignCount },
-            { "warnings", warnings },
-            { "engineSourceLanguageTag", sourceLanguageTag },
-            { "engineTargetLanguageTag", targetLanguageTag },
+            TrainCount = trainCount,
+            WordAlignCount = wordAlignCount,
+            Warnings = warnings,
+            EngineSourceLanguageTag = sourceLanguageTag,
+            EngineTargetLanguageTag = targetLanguageTag
         };
         await PlatformService.UpdateBuildExecutionDataAsync(engineId, buildId, executionData, cancellationToken);
     }

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/ClearMLMonitorServiceTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/ClearMLMonitorServiceTests.cs
@@ -110,7 +110,8 @@ public class ClearMLMonitorServiceTests
                 JobId = jobId,
                 JobState = jobState,
                 BuildJobRunner = BuildJobRunnerType.ClearML,
-                Stage = stage
+                Stage = stage,
+                ExecutionData = new BuildExecutionData()
             },
             SourceLanguage = "en",
             TargetLanguage = "fr",

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/NmtClearMLBuildJobFactoryTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/NmtClearMLBuildJobFactoryTests.cs
@@ -92,7 +92,8 @@ run(args)
                         JobId = "job1",
                         BuildJobRunner = BuildJobRunnerType.ClearML,
                         Stage = BuildStage.Train,
-                        JobState = BuildJobState.Pending
+                        JobState = BuildJobState.Pending,
+                        ExecutionData = new BuildExecutionData()
                     }
                 }
             );

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/PreprocessBuildJobTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/PreprocessBuildJobTests.cs
@@ -129,9 +129,7 @@ public class PreprocessBuildJobTests
         ParallelCorpus corpus1 = env.DefaultParatextCorpus;
 
         await env.RunBuildJobAsync(corpus1, useKeyTerms: true);
-
-        Assert.That(env.ExecutionData.ContainsKey("warnings"));
-        Assert.That(env.ExecutionData["warnings"] as List<string>, Has.Count.EqualTo(8));
+        Assert.That(env.ExecutionData.Warnings, Has.Count.EqualTo(8));
     }
 
     [Test]
@@ -492,8 +490,7 @@ Target one, chapter one, verse nine and ten.
         public ParallelCorpus DefaultParatextCorpus { get; }
         public ParallelCorpus DefaultMixedSourceParatextCorpus { get; }
 
-        public IReadOnlyDictionary<string, object> ExecutionData { get; private set; } =
-            new Dictionary<string, object>();
+        public BuildExecutionData ExecutionData { get; private set; } = new BuildExecutionData();
 
         public TestEnvironment()
         {
@@ -639,7 +636,8 @@ Target one, chapter one, verse nine and ten.
                         JobId = "job1",
                         JobState = BuildJobState.Pending,
                         BuildJobRunner = BuildJobRunnerType.Hangfire,
-                        Stage = BuildStage.Preprocess
+                        Stage = BuildStage.Preprocess,
+                        ExecutionData = new BuildExecutionData()
                     }
                 }
             );
@@ -659,7 +657,8 @@ Target one, chapter one, verse nine and ten.
                         JobId = "job1",
                         JobState = BuildJobState.Pending,
                         BuildJobRunner = BuildJobRunnerType.Hangfire,
-                        Stage = BuildStage.Preprocess
+                        Stage = BuildStage.Preprocess,
+                        ExecutionData = new BuildExecutionData()
                     }
                 }
             );
@@ -679,7 +678,8 @@ Target one, chapter one, verse nine and ten.
                         JobId = "job1",
                         JobState = BuildJobState.Pending,
                         BuildJobRunner = BuildJobRunnerType.Hangfire,
-                        Stage = BuildStage.Preprocess
+                        Stage = BuildStage.Preprocess,
+                        ExecutionData = new BuildExecutionData()
                     }
                 }
             );
@@ -690,7 +690,7 @@ Target one, chapter one, verse nine and ten.
             PlatformService.UpdateBuildExecutionDataAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Do<IReadOnlyDictionary<string, object>>(data => ExecutionData = data),
+                Arg.Do<BuildExecutionData>(data => ExecutionData = data),
                 Arg.Any<CancellationToken>()
             );
             LockFactory = new DistributedReaderWriterLockFactory(

--- a/src/Serval/src/Serval.Client/Client.g.cs
+++ b/src/Serval/src/Serval.Client/Client.g.cs
@@ -10979,8 +10979,9 @@ namespace Serval.Client
         [Newtonsoft.Json.JsonProperty("deploymentVersion", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string? DeploymentVersion { get; set; } = default!;
 
-        [Newtonsoft.Json.JsonProperty("executionData", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.IDictionary<string, object>? ExecutionData { get; set; } = default!;
+        [Newtonsoft.Json.JsonProperty("executionData", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public ExecutionData ExecutionData { get; set; } = new ExecutionData();
 
         [Newtonsoft.Json.JsonProperty("phases", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IList<Phase>? Phases { get; set; } = default!;
@@ -11072,6 +11073,33 @@ namespace Serval.Client
 
         [System.Runtime.Serialization.EnumMember(Value = @"Canceled")]
         Canceled = 4,
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.1.0.0 (NJsonSchema v11.0.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class ExecutionData
+    {
+        [Newtonsoft.Json.JsonProperty("trainCount", Required = Newtonsoft.Json.Required.Always)]
+        public int TrainCount { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("pretranslateCount", Required = Newtonsoft.Json.Required.Always)]
+        public int PretranslateCount { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("warnings", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.IList<string> Warnings { get; set; } = new System.Collections.ObjectModel.Collection<string>();
+
+        [Newtonsoft.Json.JsonProperty("engineSourceLanguageTag", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? EngineSourceLanguageTag { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("engineTargetLanguageTag", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? EngineTargetLanguageTag { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("resolvedSourceLanguage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? ResolvedSourceLanguage { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("resolvedTargetLanguage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? ResolvedTargetLanguage { get; set; } = default!;
 
     }
 
@@ -11554,8 +11582,9 @@ namespace Serval.Client
         [Newtonsoft.Json.JsonProperty("deploymentVersion", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string? DeploymentVersion { get; set; } = default!;
 
-        [Newtonsoft.Json.JsonProperty("executionData", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.IDictionary<string, object>? ExecutionData { get; set; } = default!;
+        [Newtonsoft.Json.JsonProperty("executionData", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public WordAlignmentExecutionData ExecutionData { get; set; } = new WordAlignmentExecutionData();
 
         [Newtonsoft.Json.JsonProperty("phases", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IList<Phase>? Phases { get; set; } = default!;
@@ -11573,6 +11602,27 @@ namespace Serval.Client
 
         [Newtonsoft.Json.JsonProperty("targetFilters", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.IList<ParallelCorpusFilter>? TargetFilters { get; set; } = default!;
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.1.0.0 (NJsonSchema v11.0.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class WordAlignmentExecutionData
+    {
+        [Newtonsoft.Json.JsonProperty("trainCount", Required = Newtonsoft.Json.Required.Always)]
+        public int TrainCount { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("wordAlignCount", Required = Newtonsoft.Json.Required.Always)]
+        public int WordAlignCount { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("warnings", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.IList<string> Warnings { get; set; } = new System.Collections.ObjectModel.Collection<string>();
+
+        [Newtonsoft.Json.JsonProperty("engineSourceLanguageTag", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? EngineSourceLanguageTag { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("engineTargetLanguageTag", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? EngineTargetLanguageTag { get; set; } = default!;
 
     }
 

--- a/src/Serval/src/Serval.Grpc/Protos/serval/translation/v1/platform.proto
+++ b/src/Serval/src/Serval.Grpc/Protos/serval/translation/v1/platform.proto
@@ -4,7 +4,6 @@ package serval.translation.v1;
 
 import "google/protobuf/empty.proto";
 import "serval/translation/v1/common.proto";
-import "google/protobuf/struct.proto";
 
 
 service TranslationPlatformApi {
@@ -72,7 +71,7 @@ message InsertPretranslationsRequest {
 message UpdateBuildExecutionDataRequest {
     string engine_id = 1;
     string build_id = 2;
-    google.protobuf.Struct execution_data = 3;
+    ExecutionData execution_data = 3;
 }
 
 message UpdateParallelCorpusAnalysisRequest {
@@ -95,4 +94,14 @@ message Phase {
 enum PhaseStage {
     PHASE_STAGE_TRAIN = 0;
     PHASE_STAGE_INFERENCE = 1;
+}
+
+message ExecutionData {
+    int32 train_count = 1;
+    int32 pretranslate_count = 2;
+    repeated string warnings = 3;
+    string engine_source_language_tag = 4;
+    string engine_target_language_tag = 5;
+    string resolved_source_language = 6;
+    string resolved_target_language = 7;
 }

--- a/src/Serval/src/Serval.Grpc/Protos/serval/word_alignment/v1/platform.proto
+++ b/src/Serval/src/Serval.Grpc/Protos/serval/word_alignment/v1/platform.proto
@@ -4,7 +4,6 @@ package serval.word_alignment.v1;
 
 import "google/protobuf/empty.proto";
 import "serval/word_alignment/v1/common.proto";
-import "google/protobuf/struct.proto";
 
 
 service WordAlignmentPlatformApi {
@@ -71,7 +70,7 @@ message InsertWordAlignmentsRequest {
 message UpdateBuildExecutionDataRequest {
     string engine_id = 1;
     string build_id = 2;
-    google.protobuf.Struct execution_data = 3;
+    ExecutionData execution_data = 3;
 }
 
 message Phase {
@@ -83,4 +82,12 @@ message Phase {
 enum PhaseStage {
     PHASE_STAGE_TRAIN = 0;
     PHASE_STAGE_INFERENCE = 1;
+}
+
+message ExecutionData {
+    int32 train_count = 1;
+    int32 word_align_count = 2;
+    repeated string warnings = 3;
+    string engine_source_language_tag = 4;
+    string engine_target_language_tag = 5;
 }

--- a/src/Serval/src/Serval.Translation/Configuration/IMongoDataAccessConfiguratorExtensions.cs
+++ b/src/Serval/src/Serval.Translation/Configuration/IMongoDataAccessConfiguratorExtensions.cs
@@ -39,7 +39,7 @@ public static class IMongoDataAccessConfiguratorExtensions
                 // migrate by adding ExecutionData field
                 await c.UpdateManyAsync(
                     Builders<Build>.Filter.Exists(b => b.ExecutionData, false),
-                    Builders<Build>.Update.Set(b => b.ExecutionData, new Dictionary<string, object>())
+                    Builders<Build>.Update.Set(b => b.ExecutionData, new ExecutionData())
                 );
                 // migrate the percentCompleted field to the progress field
                 await c.UpdateManyAsync(

--- a/src/Serval/src/Serval.Translation/Contracts/ExecutionDataDto.cs
+++ b/src/Serval/src/Serval.Translation/Contracts/ExecutionDataDto.cs
@@ -1,0 +1,12 @@
+namespace Serval.Translation.Contracts;
+
+public record ExecutionDataDto
+{
+    public int TrainCount { get; init; }
+    public int PretranslateCount { get; init; }
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+    public string? EngineSourceLanguageTag { get; init; }
+    public string? EngineTargetLanguageTag { get; init; }
+    public string? ResolvedSourceLanguage { get; init; }
+    public string? ResolvedTargetLanguage { get; init; }
+}

--- a/src/Serval/src/Serval.Translation/Contracts/TranslationBuildDto.cs
+++ b/src/Serval/src/Serval.Translation/Contracts/TranslationBuildDto.cs
@@ -31,7 +31,7 @@ public record TranslationBuildDto
     /// </example>
     public object? Options { get; init; }
     public string? DeploymentVersion { get; init; }
-    public IReadOnlyDictionary<string, object>? ExecutionData { get; init; }
+    public required ExecutionDataDto ExecutionData { get; init; }
     public IReadOnlyList<PhaseDto>? Phases { get; init; }
     public IReadOnlyList<ParallelCorpusAnalysisDto>? Analysis { get; init; }
 }

--- a/src/Serval/src/Serval.Translation/Controllers/TranslationEnginesController.cs
+++ b/src/Serval/src/Serval.Translation/Controllers/TranslationEnginesController.cs
@@ -1960,7 +1960,7 @@ public class TranslationEnginesController(
             DateFinished = source.DateFinished,
             Options = source.Options,
             DeploymentVersion = source.DeploymentVersion,
-            ExecutionData = source.ExecutionData,
+            ExecutionData = Map(source.ExecutionData),
             Phases = source.Phases?.Select(Map).ToList(),
             Analysis = source.Analysis?.Select(Map).ToList(),
         };
@@ -2199,6 +2199,20 @@ public class TranslationEnginesController(
             TargetQuoteConvention = source.TargetQuoteConvention,
             SourceQuoteConvention = "ignore",
             CanDenormalizeQuotes = source.TargetQuoteConvention != ""
+        };
+    }
+
+    private static ExecutionDataDto Map(ExecutionData source)
+    {
+        return new ExecutionDataDto
+        {
+            TrainCount = source.TrainCount ?? 0,
+            PretranslateCount = source.PretranslateCount ?? 0,
+            Warnings = source.Warnings ?? [],
+            EngineSourceLanguageTag = source.EngineSourceLanguageTag,
+            EngineTargetLanguageTag = source.EngineTargetLanguageTag,
+            ResolvedSourceLanguage = source.ResolvedSourceLanguage,
+            ResolvedTargetLanguage = source.ResolvedTargetLanguage,
         };
     }
 }

--- a/src/Serval/src/Serval.Translation/Models/Build.cs
+++ b/src/Serval/src/Serval.Translation/Models/Build.cs
@@ -16,7 +16,7 @@ public record Build : IEntity
     public DateTime? DateFinished { get; init; }
     public IReadOnlyDictionary<string, object>? Options { get; init; }
     public string? DeploymentVersion { get; init; }
-    public IReadOnlyDictionary<string, object> ExecutionData { get; init; } = new Dictionary<string, object>();
+    public ExecutionData ExecutionData { get; init; } = new ExecutionData();
     public DateTime? DateCreated { get; set; }
     public IReadOnlyList<BuildPhase>? Phases { get; init; }
     public IReadOnlyList<ParallelCorpusAnalysis>? Analysis { get; init; }

--- a/src/Serval/src/Serval.Translation/Models/ExecutionData.cs
+++ b/src/Serval/src/Serval.Translation/Models/ExecutionData.cs
@@ -1,0 +1,12 @@
+namespace Serval.Translation.Models;
+
+public record ExecutionData
+{
+    public int? TrainCount { get; init; }
+    public int? PretranslateCount { get; init; }
+    public IReadOnlyList<string>? Warnings { get; init; }
+    public string? EngineSourceLanguageTag { get; init; }
+    public string? EngineTargetLanguageTag { get; init; }
+    public string? ResolvedSourceLanguage { get; init; }
+    public string? ResolvedTargetLanguage { get; init; }
+}

--- a/src/Serval/src/Serval.Translation/Services/TranslationPlatformServiceV1.cs
+++ b/src/Serval/src/Serval.Translation/Services/TranslationPlatformServiceV1.cs
@@ -279,30 +279,22 @@ public class TranslationPlatformServiceV1(
         ServerCallContext context
     )
     {
-        static object Map(Value value)
-        {
-            if (value.HasStringValue)
-            {
-                return value.StringValue;
-            }
-            else if (value.HasNumberValue)
-            {
-                return value.NumberValue;
-            }
-            else if (value.ListValue.Values.Count > 0)
-            {
-                return new List<string>(value.ListValue.Values.Select(v => v.StringValue));
-            }
-            return -1;
-        }
         await _builds.UpdateAsync(
             b => b.Id == request.BuildId,
             u =>
-            {
-                // initialize ExecutionData if it's null
-                foreach (KeyValuePair<string, Value> entry in request.ExecutionData.Fields)
-                    u.Set(b => b.ExecutionData[entry.Key], Map(entry.Value));
-            },
+                u.Set(
+                    b => b.ExecutionData,
+                    new Models.ExecutionData
+                    {
+                        TrainCount = request.ExecutionData.TrainCount,
+                        PretranslateCount = request.ExecutionData.PretranslateCount,
+                        Warnings = [.. request.ExecutionData.Warnings],
+                        EngineSourceLanguageTag = request.ExecutionData.EngineSourceLanguageTag,
+                        EngineTargetLanguageTag = request.ExecutionData.EngineTargetLanguageTag,
+                        ResolvedSourceLanguage = request.ExecutionData.ResolvedSourceLanguage,
+                        ResolvedTargetLanguage = request.ExecutionData.ResolvedTargetLanguage
+                    }
+                ),
             cancellationToken: context.CancellationToken
         );
 

--- a/src/Serval/src/Serval.WordAlignment/Contracts/WordAlignmentBuildDto.cs
+++ b/src/Serval/src/Serval.WordAlignment/Contracts/WordAlignmentBuildDto.cs
@@ -31,6 +31,6 @@ public record WordAlignmentBuildDto
     /// </example>
     public object? Options { get; init; }
     public string? DeploymentVersion { get; init; }
-    public IReadOnlyDictionary<string, object>? ExecutionData { get; init; }
+    public required WordAlignmentExecutionDataDto ExecutionData { get; init; }
     public IReadOnlyList<PhaseDto>? Phases { get; init; }
 }

--- a/src/Serval/src/Serval.WordAlignment/Contracts/WordAlignmentExecutionDataDto.cs
+++ b/src/Serval/src/Serval.WordAlignment/Contracts/WordAlignmentExecutionDataDto.cs
@@ -1,0 +1,10 @@
+namespace Serval.WordAlignment.Contracts;
+
+public record WordAlignmentExecutionDataDto
+{
+    public int TrainCount { get; init; }
+    public int WordAlignCount { get; init; }
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+    public string? EngineSourceLanguageTag { get; init; }
+    public string? EngineTargetLanguageTag { get; init; }
+}

--- a/src/Serval/src/Serval.WordAlignment/Controllers/WordAlignmentEnginesController.cs
+++ b/src/Serval/src/Serval.WordAlignment/Controllers/WordAlignmentEnginesController.cs
@@ -978,7 +978,7 @@ public class WordAlignmentEnginesController(
             DateFinished = source.DateFinished,
             Options = source.Options,
             DeploymentVersion = source.DeploymentVersion,
-            ExecutionData = source.ExecutionData,
+            ExecutionData = Map(source.ExecutionData),
             Phases = source.Phases?.Select(Map).ToList()
         };
     }
@@ -1096,6 +1096,18 @@ public class WordAlignmentEnginesController(
             Stage = (PhaseStage)source.Stage,
             Step = source.Step,
             StepCount = source.StepCount
+        };
+    }
+
+    private static WordAlignmentExecutionDataDto Map(ExecutionData source)
+    {
+        return new WordAlignmentExecutionDataDto
+        {
+            TrainCount = source.TrainCount ?? 0,
+            WordAlignCount = source.WordAlignCount ?? 0,
+            Warnings = source.Warnings ?? [],
+            EngineSourceLanguageTag = source.EngineSourceLanguageTag,
+            EngineTargetLanguageTag = source.EngineTargetLanguageTag,
         };
     }
 }

--- a/src/Serval/src/Serval.WordAlignment/Models/Build.cs
+++ b/src/Serval/src/Serval.WordAlignment/Models/Build.cs
@@ -16,7 +16,7 @@ public record Build : IEntity
     public DateTime? DateFinished { get; init; }
     public IReadOnlyDictionary<string, object>? Options { get; init; }
     public string? DeploymentVersion { get; init; }
-    public IReadOnlyDictionary<string, object> ExecutionData { get; init; } = new Dictionary<string, object>();
+    public ExecutionData ExecutionData { get; init; } = new ExecutionData();
     public DateTime? DateCreated { get; set; }
     public IReadOnlyList<BuildPhase>? Phases { get; init; }
 }

--- a/src/Serval/src/Serval.WordAlignment/Models/ExecutionData.cs
+++ b/src/Serval/src/Serval.WordAlignment/Models/ExecutionData.cs
@@ -1,0 +1,10 @@
+namespace Serval.WordAlignment.Models;
+
+public record ExecutionData
+{
+    public int? TrainCount { get; init; }
+    public int? WordAlignCount { get; init; }
+    public IReadOnlyList<string>? Warnings { get; init; }
+    public string? EngineSourceLanguageTag { get; init; }
+    public string? EngineTargetLanguageTag { get; init; }
+}

--- a/src/Serval/src/Serval.WordAlignment/Services/WordAlignmentPlatformServiceV1.cs
+++ b/src/Serval/src/Serval.WordAlignment/Services/WordAlignmentPlatformServiceV1.cs
@@ -343,30 +343,20 @@ public class WordAlignmentPlatformServiceV1(
         ServerCallContext context
     )
     {
-        static object Map(Value value)
-        {
-            if (value.HasStringValue)
-            {
-                return value.StringValue;
-            }
-            else if (value.HasNumberValue)
-            {
-                return value.NumberValue;
-            }
-            else if (value.ListValue.Values.Count > 0)
-            {
-                return new List<string>(value.ListValue.Values.Select(v => v.StringValue));
-            }
-            return -1;
-        }
         await _builds.UpdateAsync(
             b => b.Id == request.BuildId,
             u =>
-            {
-                // initialize ExecutionData if it's null
-                foreach (KeyValuePair<string, Value> entry in request.ExecutionData.Fields)
-                    u.Set(b => b.ExecutionData[entry.Key], Map(entry.Value));
-            },
+                u.Set(
+                    b => b.ExecutionData,
+                    new Models.ExecutionData
+                    {
+                        TrainCount = request.ExecutionData.TrainCount,
+                        WordAlignCount = request.ExecutionData.WordAlignCount,
+                        Warnings = [.. request.ExecutionData.Warnings],
+                        EngineSourceLanguageTag = request.ExecutionData.EngineSourceLanguageTag,
+                        EngineTargetLanguageTag = request.ExecutionData.EngineTargetLanguageTag
+                    }
+                ),
             cancellationToken: context.CancellationToken
         );
 

--- a/src/Serval/test/Serval.E2ETests/ServalApiTests.cs
+++ b/src/Serval/test/Serval.E2ETests/ServalApiTests.cs
@@ -179,14 +179,8 @@ public class ServalApiTests
 
         var executionData = build.ExecutionData;
 
-        Assert.That(executionData, Contains.Key("trainCount"));
-        Assert.That(executionData, Contains.Key("pretranslateCount"));
-
-        int trainCount = Convert.ToInt32(executionData["trainCount"], CultureInfo.InvariantCulture);
-        int pretranslateCount = Convert.ToInt32(executionData["pretranslateCount"], CultureInfo.InvariantCulture);
-
-        Assert.That(trainCount, Is.GreaterThan(0));
-        Assert.That(pretranslateCount, Is.GreaterThan(0));
+        Assert.That(executionData.TrainCount, Is.GreaterThan(0));
+        Assert.That(executionData.PretranslateCount, Is.GreaterThan(0));
 
         Assert.That(lTrans2, Has.Count.EqualTo(13)); // just 2 John
     }
@@ -515,14 +509,8 @@ public class ServalApiTests
 
         var executionData = build.ExecutionData;
 
-        Assert.That(executionData, Contains.Key("trainCount"));
-        Assert.That(executionData, Contains.Key("wordAlignCount"));
-
-        int trainCount = Convert.ToInt32(executionData["trainCount"], CultureInfo.InvariantCulture);
-        int wordAlignmentCount = Convert.ToInt32(executionData["wordAlignCount"], CultureInfo.InvariantCulture);
-
-        Assert.That(trainCount, Is.GreaterThan(0));
-        Assert.That(wordAlignmentCount, Is.GreaterThan(0));
+        Assert.That(executionData.TrainCount, Is.GreaterThan(0));
+        Assert.That(executionData.WordAlignCount, Is.GreaterThan(0));
 
         IList<Client.WordAlignment> wordAlignments =
             await _helperClient.WordAlignmentEnginesClient.GetAllWordAlignmentsAsync(engineId, corpusId);

--- a/src/Serval/test/Serval.WordAlignment.Tests/Services/PlatformServiceTests.cs
+++ b/src/Serval/test/Serval.WordAlignment.Tests/Services/PlatformServiceTests.cs
@@ -1,5 +1,5 @@
-using System.Globalization;
 using Serval.WordAlignment.V1;
+using ExecutionData = Serval.WordAlignment.Models.ExecutionData;
 
 namespace Serval.WordAlignment.Services;
 
@@ -120,12 +120,7 @@ public class PlatformServiceTests
         {
             Id = "123",
             EngineRef = "e0",
-            ExecutionData = new Dictionary<string, object>
-            {
-                { "trainCount", "0" },
-                { "wordAlignCount", "0" },
-                { "staticCount", "0" }
-            }
+            ExecutionData = new ExecutionData { TrainCount = 0, WordAlignCount = 0 }
         };
         await env.Builds.InsertAsync(build);
 
@@ -133,46 +128,25 @@ public class PlatformServiceTests
 
         var executionData = build.ExecutionData;
 
-        Assert.That(executionData, Contains.Key("trainCount"));
-        Assert.That(executionData, Contains.Key("wordAlignCount"));
-
-        int trainCount = Convert.ToInt32(executionData["trainCount"], CultureInfo.InvariantCulture);
-        int wordAlignmentCount = Convert.ToInt32(executionData["wordAlignCount"], CultureInfo.InvariantCulture);
-        int staticCount = Convert.ToInt32(executionData["staticCount"], CultureInfo.InvariantCulture);
-
-        Assert.That(trainCount, Is.EqualTo(0));
-        Assert.That(wordAlignmentCount, Is.EqualTo(0));
-        Assert.That(staticCount, Is.EqualTo(0));
+        Assert.That(executionData.TrainCount, Is.EqualTo(0));
+        Assert.That(executionData.WordAlignCount, Is.EqualTo(0));
 
         var updateRequest = new UpdateBuildExecutionDataRequest()
         {
             BuildId = "123",
             EngineId = engine.Id,
-            ExecutionData = new Google.Protobuf.WellKnownTypes.Struct()
+            ExecutionData = new V1.ExecutionData { TrainCount = 4, WordAlignCount = 5, }
         };
-
-        updateRequest.ExecutionData.Fields.Add(
-            "trainCount",
-            new Google.Protobuf.WellKnownTypes.Value() { StringValue = "4" }
-        );
-        updateRequest.ExecutionData.Fields.Add(
-            "wordAlignCount",
-            new Google.Protobuf.WellKnownTypes.Value() { StringValue = "5" }
-        );
 
         await env.PlatformService.UpdateBuildExecutionData(updateRequest, env.ServerCallContext);
 
         build = await env.Builds.GetAsync(c => c.Id == build.Id);
 
-        executionData = build!.ExecutionData;
+        executionData = build?.ExecutionData;
 
-        trainCount = Convert.ToInt32(executionData["trainCount"], CultureInfo.InvariantCulture);
-        wordAlignmentCount = Convert.ToInt32(executionData["wordAlignCount"], CultureInfo.InvariantCulture);
-        staticCount = Convert.ToInt32(executionData["staticCount"], CultureInfo.InvariantCulture);
-
-        Assert.That(trainCount, Is.GreaterThan(0));
-        Assert.That(wordAlignmentCount, Is.GreaterThan(0));
-        Assert.That(staticCount, Is.EqualTo(0));
+        Assert.That(executionData, Is.Not.Null);
+        Assert.That(executionData.TrainCount, Is.GreaterThan(0));
+        Assert.That(executionData.WordAlignCount, Is.GreaterThan(0));
     }
 
     [Test]


### PR DESCRIPTION
This PR fixes the following bugs:

**1. Word Alignment builds fail with the following exception:**

*(This was exposed by the WordAlignment e2e test failure)*

```
fail: Serval.Machine.Shared.Services.WordAlignmentPreprocessBuildJob[0]
      Build faulted (6910fc03ef13696373a5d52f)
      System.InvalidCastException: Unable to cast object of type 'System.Collections.Generic.Dictionary`2[System.String,System.Object]' to type 'System.Collections.Generic.IDictionary`2[System.String,System.String]'.
         at Serval.Machine.Shared.Services.ServalWordAlignmentPlatformService.UpdateBuildExecutionDataAsync(String engineId, String buildId, IReadOnlyDictionary`2 executionData, CancellationToken cancellationToken) in /home/peter/source/serval/src/Machine/src/Serval.Machine.Shared/Services/ServalWordAlignmentPlatformService.cs:line 157
         at Serval.Machine.Shared.Services.WordAlignmentPreprocessBuildJob.UpdateBuildExecutionData(String engineId, String buildId, Int32 trainCount, Int32 wordAlignCount, String sourceLanguageTag, String targetLanguageTag, IReadOnlyList`1 corpora, CancellationToken cancellationToken) in /home/peter/source/serval/src/Machine/src/Serval.Machine.Shared/Services/WordAlignmentPreprocessBuildJob.cs:line 126
         at Serval.Machine.Shared.Services.PreprocessBuildJob`1.DoWorkAsync(String engineId, String buildId, IReadOnlyList`1 data, String buildOptions, CancellationToken cancellationToken) in /home/peter/source/serval/src/Machine/src/Serval.Machine.Shared/Services/PreprocessBuildJob.cs:line 51
         at Serval.Machine.Shared.Services.HangfireBuildJob`2.RunAsync(String engineId, String buildId, TData data, String buildOptions, CancellationToken cancellationToken) in /home/peter/source/serval/src/Machine/src/Serval.Machine.Shared/Services/HangfireBuildJob.cs:line 56
```

**2. Serval.Client fails to deserialize builds when warnings are present in execution data, throwing an exception similar to the following:**

```
Serval.Client.ServalApiException: Could not deserialize the response body stream as Serval.Client.TranslationBuild.

Status: 200
Response: 

 ---> Newtonsoft.Json.JsonReaderException: Unexpected character encountered while parsing value: [. Path 'executionData.warnings', line 1, position 1326.
   at Newtonsoft.Json.JsonTextReader.ReadStringValue(ReadType readType)
   at Newtonsoft.Json.JsonTextReader.ReadAsString()
   at Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateDictionary(IDictionary dictionary, JsonReader reader, JsonDictionaryContract contract, JsonProperty containerProperty, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize[T](JsonReader reader)
   at Serval.Client.TranslationEnginesClient.ReadObjectResponseAsync[T](HttpResponseMessage response, IReadOnlyDictionary`2 headers, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at Serval.Client.TranslationEnginesClient.ReadObjectResponseAsync[T](HttpResponseMessage response, IReadOnlyDictionary`2 headers, CancellationToken cancellationToken)
   at Serval.Client.TranslationEnginesClient.CancelBuildAsync(String id, CancellationToken cancellationToken)
   at Program.<>c__DisplayClass0_0.<<<Main>$>g__CreatePreTranslationEngineAsync|2>d.MoveNext() in /home/peter/source/serval/samples/ApiExample/Program.cs:line 312
--- End of stack trace from previous location ---
   at Program.<Main>$(String[] args) in /home/peter/source/serval/samples/ApiExample/Program.cs:line 26
   at Program.<Main>(String[] args)

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/823)
<!-- Reviewable:end -->
