### PR TITLE
Improve build warnings (esp. USFM versification errors)

### DIFF
--- a/src/Machine/src/Serval.Machine.Shared/Configuration/BuildJobOptions.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Configuration/BuildJobOptions.cs
@@ -6,4 +6,5 @@ public class BuildJobOptions
 
     public IList<ClearMLBuildQueue> ClearML { get; set; } = new List<ClearMLBuildQueue>();
     public bool PreserveBuildFiles { get; set; } = false;
+    public int MaxWarnings { get; set; } = 1000;
 }

--- a/src/Machine/src/Serval.Machine.Shared/Services/NmtPreprocessBuildJob.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/NmtPreprocessBuildJob.cs
@@ -8,7 +8,8 @@ public class NmtPreprocessBuildJob(
     IBuildJobService<TranslationEngine> buildJobService,
     ISharedFileService sharedFileService,
     ILanguageTagService languageTagService,
-    IParallelCorpusPreprocessingService parallelCorpusPreprocessingService
+    IParallelCorpusPreprocessingService parallelCorpusPreprocessingService,
+    IOptionsMonitor<BuildJobOptions> options
 )
     : TranslationPreprocessBuildJob(
         platformService,
@@ -17,7 +18,8 @@ public class NmtPreprocessBuildJob(
         logger,
         buildJobService,
         sharedFileService,
-        parallelCorpusPreprocessingService
+        parallelCorpusPreprocessingService,
+        options
     )
 {
     private readonly ILanguageTagService _languageTagService = languageTagService;
@@ -86,6 +88,14 @@ public class NmtPreprocessBuildJob(
             targetLanguageTag,
             corpora
         );
+
+        int maxWarnings = BuildJobOptions.MaxWarnings;
+        if (warnings.Count > maxWarnings)
+        {
+            string tooManyWarningsWarning =
+                $"There were {warnings.Count} warnings. Only the first {maxWarnings} are shown.";
+            warnings = [tooManyWarningsWarning, .. warnings.Take(maxWarnings)];
+        }
 
         // Log summary of build data
         JsonObject buildPreprocessSummary =

--- a/src/Machine/src/Serval.Machine.Shared/Services/PreprocessBuildJob.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/PreprocessBuildJob.cs
@@ -7,7 +7,8 @@ public abstract class PreprocessBuildJob<TEngine>(
     ILogger<PreprocessBuildJob<TEngine>> logger,
     IBuildJobService<TEngine> buildJobService,
     ISharedFileService sharedFileService,
-    IParallelCorpusPreprocessingService parallelCorpusPreprocessingService
+    IParallelCorpusPreprocessingService parallelCorpusPreprocessingService,
+    IOptionsMonitor<BuildJobOptions> options
 )
     : HangfireBuildJob<TEngine, IReadOnlyList<ParallelCorpus>>(
         platformService,
@@ -24,7 +25,7 @@ public abstract class PreprocessBuildJob<TEngine>(
         new() { Indented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
 
     internal BuildJobRunnerType TrainJobRunnerType { get; init; } = BuildJobRunnerType.ClearML;
-
+    protected readonly BuildJobOptions BuildJobOptions = options.CurrentValue;
     protected readonly ISharedFileService SharedFileService = sharedFileService;
     protected readonly IParallelCorpusPreprocessingService ParallelCorpusPreprocessingService =
         parallelCorpusPreprocessingService;
@@ -148,7 +149,7 @@ public abstract class PreprocessBuildJob<TEngine>(
                 foreach (UsfmVersificationError error in errors)
                 {
                     warnings.Add(
-                        $"USFM does not match project versification for parallel corpus {parallelCorpus.Id}, monolingual corpus {monolingualCorpusId}: Expected verse {error.ExpectedVerseRef}, Actual verse {error.ActualVerseRef}, Mismatch type {error.Type}"
+                        $"USFM versification error in project {error.ProjectName}, expected verse “{error.ExpectedVerseRef}”, actual verse “{error.ActualVerseRef}”, mismatch type {error.Type} (parallel corpus {parallelCorpus.Id}, monolingual corpus {monolingualCorpusId})"
                     );
                 }
             }

--- a/src/Machine/src/Serval.Machine.Shared/Services/SmtTransferPreprocessBuildJob.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/SmtTransferPreprocessBuildJob.cs
@@ -9,7 +9,8 @@ public class SmtTransferPreprocessBuildJob(
     ISharedFileService sharedFileService,
     IDistributedReaderWriterLockFactory lockFactory,
     IRepository<TrainSegmentPair> trainSegmentPairs,
-    IParallelCorpusPreprocessingService parallelCorpusPreprocessingService
+    IParallelCorpusPreprocessingService parallelCorpusPreprocessingService,
+    IOptionsMonitor<BuildJobOptions> options
 )
     : TranslationPreprocessBuildJob(
         platformService,
@@ -18,7 +19,8 @@ public class SmtTransferPreprocessBuildJob(
         logger,
         buildJobService,
         sharedFileService,
-        parallelCorpusPreprocessingService
+        parallelCorpusPreprocessingService,
+        options
     )
 {
     private readonly IDistributedReaderWriterLockFactory _lockFactory = lockFactory;

--- a/src/Machine/src/Serval.Machine.Shared/Services/TranslationPreprocessBuildJob.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/TranslationPreprocessBuildJob.cs
@@ -7,7 +7,8 @@ public class TranslationPreprocessBuildJob(
     ILogger<PreprocessBuildJob<TranslationEngine>> logger,
     IBuildJobService<TranslationEngine> buildJobService,
     ISharedFileService sharedFileService,
-    IParallelCorpusPreprocessingService parallelCorpusPreprocessingService
+    IParallelCorpusPreprocessingService parallelCorpusPreprocessingService,
+    IOptionsMonitor<BuildJobOptions> options
 )
     : PreprocessBuildJob<TranslationEngine>(
         platformService,
@@ -16,7 +17,8 @@ public class TranslationPreprocessBuildJob(
         logger,
         buildJobService,
         sharedFileService,
-        parallelCorpusPreprocessingService
+        parallelCorpusPreprocessingService,
+        options
     )
 {
     protected override async Task<(int TrainCount, int InferenceCount)> WriteDataFilesAsync(

--- a/src/Machine/src/Serval.Machine.Shared/Services/WordAlignmentPreprocessBuildJob.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/WordAlignmentPreprocessBuildJob.cs
@@ -7,7 +7,8 @@ public class WordAlignmentPreprocessBuildJob(
     ILogger<WordAlignmentPreprocessBuildJob> logger,
     IBuildJobService<WordAlignmentEngine> buildJobService,
     ISharedFileService sharedFileService,
-    IParallelCorpusPreprocessingService parallelCorpusPreprocessingService
+    IParallelCorpusPreprocessingService parallelCorpusPreprocessingService,
+    IOptionsMonitor<BuildJobOptions> options
 )
     : PreprocessBuildJob<WordAlignmentEngine>(
         platformService,
@@ -16,7 +17,8 @@ public class WordAlignmentPreprocessBuildJob(
         logger,
         buildJobService,
         sharedFileService,
-        parallelCorpusPreprocessingService
+        parallelCorpusPreprocessingService,
+        options
     )
 {
     protected override async Task<(int TrainCount, int InferenceCount)> WriteDataFilesAsync(

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/NmtEngineServiceTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/NmtEngineServiceTests.cs
@@ -146,8 +146,8 @@ public class NmtEngineServiceTests
                 .When(x => x.StopTaskAsync("job1", Arg.Any<CancellationToken>()))
                 .Do(_ => _cancellationTokenSource.Cancel());
             SharedFileService = new SharedFileService(Substitute.For<ILoggerFactory>());
-            var buildJobOptions = Substitute.For<IOptionsMonitor<BuildJobOptions>>();
-            buildJobOptions.CurrentValue.Returns(
+            BuildJobOptions = Substitute.For<IOptionsMonitor<BuildJobOptions>>();
+            BuildJobOptions.CurrentValue.Returns(
                 new BuildJobOptions
                 {
                     ClearML =
@@ -181,7 +181,7 @@ public class NmtEngineServiceTests
                                 Engines
                             )
                         ],
-                        buildJobOptions
+                        BuildJobOptions
                     )
                 ],
                 Engines
@@ -193,7 +193,7 @@ public class NmtEngineServiceTests
                 ClearMLService,
                 SharedFileService,
                 clearMLOptions,
-                buildJobOptions,
+                BuildJobOptions,
                 Substitute.For<ILogger<ClearMLMonitorService>>()
             );
             _jobServer = CreateJobServer();
@@ -207,6 +207,7 @@ public class NmtEngineServiceTests
         public IClearMLService ClearMLService { get; }
         public ISharedFileService SharedFileService { get; }
         public IBuildJobService<TranslationEngine> BuildJobService { get; }
+        public IOptionsMonitor<BuildJobOptions> BuildJobOptions { get; }
 
         public void PersistModel()
         {
@@ -329,7 +330,8 @@ public class NmtEngineServiceTests
                         _env.BuildJobService,
                         _env.SharedFileService,
                         new LanguageTagService(),
-                        new ParallelCorpusPreprocessingService(new TextCorpusService())
+                        new ParallelCorpusPreprocessingService(new TextCorpusService()),
+                        _env.BuildJobOptions
                     );
                 }
                 if (jobType == typeof(TranslationPostprocessBuildJob))
@@ -343,7 +345,7 @@ public class NmtEngineServiceTests
                         _env.BuildJobService,
                         Substitute.For<ILogger<TranslationPostprocessBuildJob>>(),
                         _env.SharedFileService,
-                        buildJobOptions
+                        _env.BuildJobOptions
                     );
                 }
                 return base.ActivateJob(jobType);

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/PreprocessBuildJobTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/PreprocessBuildJobTests.cs
@@ -130,6 +130,11 @@ public class PreprocessBuildJobTests
 
         await env.RunBuildJobAsync(corpus1, useKeyTerms: true);
         Assert.That(env.ExecutionData.Warnings, Has.Count.EqualTo(8));
+
+        env.BuildJobOptions.CurrentValue.Returns(new BuildJobOptions() { MaxWarnings = 2 });
+        await env.RunBuildJobAsync(corpus1, useKeyTerms: true);
+        // Two warnings after truncation + one warning mentioning that warnings were truncated
+        Assert.That(env.ExecutionData.Warnings, Has.Count.EqualTo(3));
     }
 
     [Test]
@@ -474,6 +479,11 @@ Target one, chapter one, verse nine and ten.
                 pretranslations[2]!["translation"]!.ToString(),
                 Is.EqualTo("Source one, chapter twelve, verse one.")
             );
+            Assert.That(
+                env.ExecutionData.Warnings,
+                Has.Count.EqualTo(16),
+                JsonSerializer.Serialize(env.ExecutionData.Warnings)
+            );
         });
     }
 
@@ -794,7 +804,8 @@ Target one, chapter one, verse nine and ten.
                         BuildJobService,
                         SharedFileService,
                         new LanguageTagService(),
-                        new ParallelCorpusPreprocessingService(TextCorpusService)
+                        new ParallelCorpusPreprocessingService(TextCorpusService),
+                        BuildJobOptions
                     );
                 }
                 case EngineType.SmtTransfer:
@@ -808,7 +819,8 @@ Target one, chapter one, verse nine and ten.
                         SharedFileService,
                         LockFactory,
                         TrainSegmentPairs,
-                        new ParallelCorpusPreprocessingService(TextCorpusService)
+                        new ParallelCorpusPreprocessingService(TextCorpusService),
+                        BuildJobOptions
                     );
                 }
                 default:

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/SmtTransferEngineServiceTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/SmtTransferEngineServiceTests.cs
@@ -288,8 +288,8 @@ public class SmtTransferEngineServiceTests
             SharedFileService = new SharedFileService(Substitute.For<ILoggerFactory>());
             var clearMLOptions = Substitute.For<IOptionsMonitor<ClearMLOptions>>();
             clearMLOptions.CurrentValue.Returns(new ClearMLOptions());
-            var buildJobOptions = Substitute.For<IOptionsMonitor<BuildJobOptions>>();
-            buildJobOptions.CurrentValue.Returns(
+            BuildJobOptions = Substitute.For<IOptionsMonitor<BuildJobOptions>>();
+            BuildJobOptions.CurrentValue.Returns(
                 new BuildJobOptions
                 {
                     ClearML =
@@ -335,7 +335,7 @@ public class SmtTransferEngineServiceTests
                 ClearMLService,
                 SharedFileService,
                 clearMLOptions,
-                buildJobOptions,
+                BuildJobOptions,
                 Substitute.For<ILogger<ClearMLMonitorService>>()
             );
             BuildJobService = new BuildJobService<TranslationEngine>(
@@ -344,7 +344,7 @@ public class SmtTransferEngineServiceTests
                     new ClearMLBuildJobRunner(
                         ClearMLService,
                         [new SmtTransferClearMLBuildJobFactory(SharedFileService, Engines)],
-                        buildJobOptions
+                        BuildJobOptions
                     )
                 ],
                 Engines
@@ -365,6 +365,7 @@ public class SmtTransferEngineServiceTests
         public ITruecaser Truecaser { get; }
         public ITrainer TruecaserTrainer { get; }
         public IPlatformService PlatformService { get; }
+        public IOptionsMonitor<BuildJobOptions> BuildJobOptions { get; }
 
         public IClearMLService ClearMLService { get; }
         public IClearMLQueueService ClearMLMonitorService { get; }
@@ -708,7 +709,8 @@ public class SmtTransferEngineServiceTests
                         _env.SharedFileService,
                         _env._lockFactory,
                         _env.TrainSegmentPairs,
-                        new ParallelCorpusPreprocessingService(new TextCorpusService())
+                        new ParallelCorpusPreprocessingService(new TextCorpusService()),
+                        _env.BuildJobOptions
                     )
                     {
                         TrainJobRunnerType = _env._trainJobRunnerType
@@ -718,8 +720,6 @@ public class SmtTransferEngineServiceTests
                 {
                     var engineOptions = Substitute.For<IOptionsMonitor<SmtTransferEngineOptions>>();
                     engineOptions.CurrentValue.Returns(new SmtTransferEngineOptions());
-                    var buildJobOptions = Substitute.For<IOptionsMonitor<BuildJobOptions>>();
-                    buildJobOptions.CurrentValue.Returns(new BuildJobOptions());
                     return new SmtTransferPostprocessBuildJob(
                         _env.PlatformService,
                         _env.Engines,
@@ -731,7 +731,7 @@ public class SmtTransferEngineServiceTests
                         _env.TrainSegmentPairs,
                         _env.SmtModelFactory,
                         _env._truecaserFactory,
-                        buildJobOptions,
+                        _env.BuildJobOptions,
                         engineOptions
                     );
                 }

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/StatisticalEngineServiceTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/StatisticalEngineServiceTests.cs
@@ -179,8 +179,8 @@ public class StatisticalEngineServiceTests
             SharedFileService = new SharedFileService(Substitute.For<ILoggerFactory>());
             var clearMLOptions = Substitute.For<IOptionsMonitor<ClearMLOptions>>();
             clearMLOptions.CurrentValue.Returns(new ClearMLOptions());
-            var buildJobOptions = Substitute.For<IOptionsMonitor<BuildJobOptions>>();
-            buildJobOptions.CurrentValue.Returns(
+            BuildJobOptions = Substitute.For<IOptionsMonitor<BuildJobOptions>>();
+            BuildJobOptions.CurrentValue.Returns(
                 new BuildJobOptions
                 {
                     ClearML =
@@ -219,7 +219,7 @@ public class StatisticalEngineServiceTests
                 ClearMLService,
                 SharedFileService,
                 clearMLOptions,
-                buildJobOptions,
+                BuildJobOptions,
                 Substitute.For<ILogger<ClearMLMonitorService>>()
             );
             BuildJobService = new BuildJobService<WordAlignmentEngine>(
@@ -228,7 +228,7 @@ public class StatisticalEngineServiceTests
                     new ClearMLBuildJobRunner(
                         ClearMLService,
                         [new StatisticalClearMLBuildJobFactory(SharedFileService, Engines)],
-                        buildJobOptions
+                        BuildJobOptions
                     )
                 ],
                 Engines
@@ -252,6 +252,7 @@ public class StatisticalEngineServiceTests
         public ISharedFileService SharedFileService { get; }
 
         public IBuildJobService<WordAlignmentEngine> BuildJobService { get; }
+        public IOptionsMonitor<BuildJobOptions> BuildJobOptions { get; }
 
         public async Task CommitAsync(TimeSpan inactiveTimeout)
         {
@@ -455,7 +456,8 @@ public class StatisticalEngineServiceTests
                         Substitute.For<ILogger<WordAlignmentPreprocessBuildJob>>(),
                         _env.BuildJobService,
                         _env.SharedFileService,
-                        new ParallelCorpusPreprocessingService(new TextCorpusService())
+                        new ParallelCorpusPreprocessingService(new TextCorpusService()),
+                        _env.BuildJobOptions
                     )
                     {
                         TrainJobRunnerType = _env._trainJobRunnerType
@@ -465,8 +467,6 @@ public class StatisticalEngineServiceTests
                 {
                     var engineOptions = Substitute.For<IOptionsMonitor<StatisticalEngineOptions>>();
                     engineOptions.CurrentValue.Returns(new StatisticalEngineOptions());
-                    var buildJobOptions = Substitute.For<IOptionsMonitor<BuildJobOptions>>();
-                    buildJobOptions.CurrentValue.Returns(new BuildJobOptions());
                     return new StatisticalPostprocessBuildJob(
                         _env.PlatformService,
                         _env.Engines,
@@ -476,7 +476,7 @@ public class StatisticalEngineServiceTests
                         _env.SharedFileService,
                         _env._lockFactory,
                         _env.WordAlignmentModelFactory,
-                        buildJobOptions,
+                        _env.BuildJobOptions,
                         engineOptions
                     );
                 }

--- a/src/ServiceToolkit/src/SIL.ServiceToolkit/Models/MonolingualCorpus.cs
+++ b/src/ServiceToolkit/src/SIL.ServiceToolkit/Models/MonolingualCorpus.cs
@@ -9,4 +9,7 @@ public record MonolingualCorpus
     public Dictionary<string, HashSet<int>>? TrainOnChapters { get; set; }
     public HashSet<string>? InferenceTextIds { get; set; }
     public Dictionary<string, HashSet<int>>? InferenceChapters { get; set; }
+
+    public bool IsFiltered =>
+        TrainOnTextIds != null || TrainOnChapters != null || InferenceTextIds != null || InferenceChapters != null;
 }

--- a/src/ServiceToolkit/src/SIL.ServiceToolkit/Services/IParallelCorpusPreprocessingService.cs
+++ b/src/ServiceToolkit/src/SIL.ServiceToolkit/Services/IParallelCorpusPreprocessingService.cs
@@ -4,7 +4,7 @@ public interface IParallelCorpusPreprocessingService
 {
     QuoteConventionAnalysis? AnalyzeTargetCorpusQuoteConvention(ParallelCorpus corpus);
     IReadOnlyList<(string CorpusId, IReadOnlyList<UsfmVersificationError> Errors)> AnalyzeUsfmVersification(
-        ParallelCorpus corpus
+        ParallelCorpus parallelCorpus
     );
 
     Task PreprocessAsync(

--- a/src/ServiceToolkit/src/SIL.ServiceToolkit/Services/ParallelCorpusPreprocessingService.cs
+++ b/src/ServiceToolkit/src/SIL.ServiceToolkit/Services/ParallelCorpusPreprocessingService.cs
@@ -14,22 +14,57 @@ public class ParallelCorpusPreprocessingService(ITextCorpusService textCorpusSer
     {
         List<(string CorpusId, IReadOnlyList<UsfmVersificationError> Errors)> errorsPerCorpus = [];
         foreach (
-            MonolingualCorpus monolingualCorpus in parallelCorpus.SourceCorpora.Concat(parallelCorpus.TargetCorpora)
+            (CorpusFile file, MonolingualCorpus monolingualCorpus, bool isSource) in parallelCorpus
+                .SourceCorpora.SelectMany(c =>
+                    c.Files.Where(f => f.Format == FileFormat.Paratext).Select(f => (f, c, true))
+                )
+                .Concat(
+                    parallelCorpus.TargetCorpora.SelectMany(c =>
+                        c.Files.Where(f => f.Format == FileFormat.Paratext).Select(f => (f, c, false))
+                    )
+                )
+                .DistinctBy(tuple => tuple.f.Location)
         )
         {
-            foreach (CorpusFile file in monolingualCorpus.Files.Where(f => f.Format == FileFormat.Paratext))
+            using ZipArchive zipArchive = ZipFile.OpenRead(file.Location);
+            IReadOnlyList<UsfmVersificationError> errors = new ZipParatextProjectVersificationErrorDetector(
+                zipArchive
+            ).GetUsfmVersificationErrors(books: GetBooks(monolingualCorpus, isSource));
+            if (errors.Count > 0)
             {
-                using ZipArchive zipArchive = ZipFile.OpenRead(file.Location);
-                IReadOnlyList<UsfmVersificationError> errors = new ZipParatextProjectVersificationErrorDetector(
-                    zipArchive
-                ).GetUsfmVersificationErrors();
-                if (errors.Count > 0)
-                {
-                    errorsPerCorpus.Add((monolingualCorpus.Id, errors));
-                }
+                errorsPerCorpus.Add((monolingualCorpus.Id, errors));
             }
         }
         return errorsPerCorpus;
+    }
+
+    private static HashSet<int>? GetBooks(MonolingualCorpus corpus, bool isSource)
+    {
+        if (!corpus.IsFiltered)
+            return null;
+
+        List<string> books = [];
+        if (corpus.TrainOnTextIds != null)
+        {
+            books.AddRange(corpus.TrainOnTextIds);
+        }
+        else if (corpus.TrainOnChapters != null)
+        {
+            books.AddRange(corpus.TrainOnChapters.Keys);
+        }
+
+        if (isSource)
+        {
+            if (corpus.InferenceTextIds != null)
+            {
+                books.AddRange(corpus.InferenceTextIds);
+            }
+            else if (corpus.InferenceChapters != null)
+            {
+                books.AddRange(corpus.InferenceChapters.Keys);
+            }
+        }
+        return [.. books.Select(bookName => Canon.BookIdToNumber(bookName))];
     }
 
     public QuoteConventionAnalysis? AnalyzeTargetCorpusQuoteConvention(ParallelCorpus parallelCorpus)


### PR DESCRIPTION
Partial fix of https://github.com/sillsdev/serval/issues/844. Requires https://github.com/sillsdev/machine/pull/368. Fixes https://github.com/sillsdev/serval/issues/841. 

Includes:
* Cap the number of warnings to 100. (Is that a good number? And do we want that to be configurable through options?)
* Utilize changes in machine to expose project name
* Reformat build warning to put information most relevant to EITL team at the beginning + improve readability of verse references by wrapping in directional quotes
* Only analyze each file once to avoid duplicate errors

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/847)
<!-- Reviewable:end -->
