### PR TITLE
Capture trace warnings from libpalaso verse and chapter parsing

### DIFF
--- a/src/Machine/src/Serval.Machine.Shared/Services/WarningsTraceListener.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/WarningsTraceListener.cs
@@ -1,0 +1,12 @@
+namespace Serval.Machine.Shared.Services;
+
+public class WarningsTraceListener(List<string> outputList, string prefix = "") : TraceListener
+{
+    public override void Write(string? message) { }
+
+    public override void WriteLine(string? message)
+    {
+        if (!string.IsNullOrWhiteSpace(message))
+            outputList.Add(prefix + message);
+    }
+}

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/WarningsTraceListenerTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/WarningsTraceListenerTests.cs
@@ -1,0 +1,61 @@
+namespace Serval.Machine.Shared.Services;
+
+[TestFixture]
+public class WarningsTraceListenerTests
+{
+    [Test]
+    public void CapturesChapterParsingWarnings()
+    {
+        using var testEnvironment = new TestEnvironment();
+        const string Chapter = "1.";
+
+        var verseRef = new VerseRef { Chapter = Chapter };
+        Assert.Multiple(() =>
+        {
+            Assert.That(verseRef.Chapter, Is.Empty);
+            Assert.That(testEnvironment.Warnings, Has.Count.EqualTo(1));
+            Assert.That(
+                testEnvironment.Warnings[0],
+                Is.EqualTo(testEnvironment.Prefix + "Just failed to parse a chapter number: " + Chapter)
+            );
+        });
+    }
+
+    [Test]
+    public void CapturesVerseParsingWarnings()
+    {
+        using var testEnvironment = new TestEnvironment();
+        const string Verse = "v1";
+
+        var verseRef = new VerseRef { Verse = Verse };
+        Assert.Multiple(() =>
+        {
+            Assert.That(verseRef.Chapter, Is.EqualTo("0"));
+            Assert.That(testEnvironment.Warnings, Has.Count.EqualTo(1));
+            Assert.That(
+                testEnvironment.Warnings[0],
+                Is.EqualTo(testEnvironment.Prefix + "Just failed to parse a verse number: " + Verse)
+            );
+        });
+    }
+
+    public class TestEnvironment : DisposableBase
+    {
+        private readonly WarningsTraceListener _listener;
+
+        public TestEnvironment()
+        {
+            _listener = new WarningsTraceListener(Warnings, Prefix);
+            Trace.Listeners.Add(_listener);
+        }
+
+        public string Prefix { get; } = "USFM Parsing error: ";
+        public List<string> Warnings { get; } = [];
+
+        protected override void DisposeManagedResources()
+        {
+            Trace.Listeners.Remove(_listener);
+            _listener.Dispose();
+        }
+    }
+}

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Usings.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Usings.cs
@@ -1,4 +1,5 @@
 ﻿global using System.Collections;
+global using System.Diagnostics;
 global using System.IO.Compression;
 global using System.Text.Json;
 global using System.Text.Json.Nodes;


### PR DESCRIPTION
Fixes [sillsdev/machine#372](https://github.com/sillsdev/machine/issues/372)

It seemed to make sense to implement this in Serval, rather than Machine as I couldn't see a clean way of maintaining the state of where the parser was to the TraceListener, without making the UsfmVersificationErrorDetector a bit more convoluted. The warnings (with the prefix in this PR) look like:

```
USFM Parsing error: Just failed to parse a chapter number: 1.
USFM Parsing error: Just failed to parse a verse number: v1
```

If you think this should be implemented in Machine not Serval, I will close this PR and reimplement there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/867)
<!-- Reviewable:end -->
