### PR TITLE
Downgrade Hangfire to 1.8.22 and Hangfire.Mongo to 1.12.2

### DIFF
--- a/src/Machine/src/Serval.Machine.Shared/Serval.Machine.Shared.csproj
+++ b/src/Machine/src/Serval.Machine.Shared/Serval.Machine.Shared.csproj
@@ -34,8 +34,8 @@
 		<PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
 		<PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />
 		<PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.76.0" />
-		<PackageReference Include="Hangfire" Version="1.8.23" />
-		<PackageReference Include="Hangfire.Mongo" Version="1.13.0" />
+		<PackageReference Include="Hangfire" Version="1.8.22" />
+		<PackageReference Include="Hangfire.Mongo" Version="1.12.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
 		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.3" />
 		<PackageReference Include="SIL.Machine" Version="3.8.0" Condition="!Exists('..\..\..\..\..\machine\src\SIL.Machine\SIL.Machine.csproj')" />

--- a/src/Serval/src/Serval.ApiServer/Serval.ApiServer.csproj
+++ b/src/Serval/src/Serval.ApiServer/Serval.ApiServer.csproj
@@ -23,8 +23,8 @@
 		<PackageReference Include="AspNetCore.HealthChecks.System" Version="9.0.0" />
 		<PackageReference Include="Bugsnag" Version="4.1.0" />
 		<PackageReference Include="Bugsnag.AspNet.Core" Version="4.1.0" />
-		<PackageReference Include="Hangfire" Version="1.8.23" />
-		<PackageReference Include="Hangfire.Mongo" Version="1.13.0" />
+		<PackageReference Include="Hangfire" Version="1.8.22" />
+		<PackageReference Include="Hangfire.Mongo" Version="1.12.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
 		<PackageReference Include="NSwag.AspNetCore" Version="14.6.3" />
 		<PackageReference Include="NSwag.MSBuild" Version="14.6.3">

--- a/src/Serval/src/Serval.Webhooks/Serval.Webhooks.csproj
+++ b/src/Serval/src/Serval.Webhooks/Serval.Webhooks.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Asp.Versioning.Abstractions" Version="8.1.0" />
-		<PackageReference Include="Hangfire.Core" Version="1.8.23" />
+		<PackageReference Include="Hangfire.Core" Version="1.8.22" />
 		<PackageReference Include="MassTransit" Version="9.0.1" />
 	</ItemGroup>
 

--- a/src/ServiceToolkit/src/SIL.ServiceToolkit/SIL.ServiceToolkit.csproj
+++ b/src/ServiceToolkit/src/SIL.ServiceToolkit/SIL.ServiceToolkit.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="Grpc.Core.Api" Version="2.76.0" />
-	  <PackageReference Include="Hangfire.Core" Version="1.8.23" />
+	  <PackageReference Include="Hangfire.Core" Version="1.8.22" />
 	  <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.32" />
 	  <PackageReference Include="Protobuf.System.Text.Json" Version="1.4.1" />
 	  <PackageReference Include="SIL.WritingSystems" Version="17.0.0" />


### PR DESCRIPTION
In my testing, it appears that the `OperationCanceledException` that are cancelling jobs are coming from Hangfire directly, when reading the JobState.

It looks like a bug in the implementation for the new `StateHistory` collection in Hangfire.Mongo reading the incorrect state (perhaps because it is reading from a shard in the MongoDB Atlas cluster that does not yet have the latest StateHistory document for the jobId?), so I have downgraded to the version of Hangfire and Hangfire.Mongo before this change was made.

In my testing, this stopped the jobs being cancelled.

The main downside of this PR is that the `serval_jobs` and `machine_jobs` collections will need to be dropped on internal QA and external QA when this PR is deployed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/876)
<!-- Reviewable:end -->
