### PR TITLE
Add endpoint to poll for the next completed build

### DIFF
--- a/src/DataAccess/src/SIL.DataAccess/ISubscription.cs
+++ b/src/DataAccess/src/SIL.DataAccess/ISubscription.cs
@@ -4,5 +4,9 @@ public interface ISubscription<T> : IDisposable
     where T : IEntity
 {
     EntityChange<T> Change { get; }
-    Task WaitForChangeAsync(TimeSpan? timeout = default, CancellationToken cancellationToken = default);
+    Task WaitForChangeAsync(
+        TimeSpan? timeout = null,
+        IReadOnlySet<EntityChangeType>? changeTypes = null,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/DataAccess/src/SIL.DataAccess/MemoryDataAccessContext.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MemoryDataAccessContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace SIL.DataAccess;
 
-public class MemoryDataAccessContext : DisposableBase, IDataAccessContext
+public class MemoryDataAccessContext : ObjectModel.DisposableBase, IDataAccessContext
 {
     public Task<TResult> WithTransactionAsync<TResult>(
         Func<CancellationToken, Task<TResult>> callbackAsync,

--- a/src/DataAccess/src/SIL.DataAccess/MemorySubscription.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MemorySubscription.cs
@@ -1,7 +1,7 @@
 namespace SIL.DataAccess;
 
 public class MemorySubscription<T>(T? initialEntity, Action<MemorySubscription<T>> remove)
-    : DisposableBase,
+    : ObjectModel.DisposableBase,
         ISubscription<T>
     where T : IEntity
 {
@@ -11,7 +11,11 @@ public class MemorySubscription<T>(T? initialEntity, Action<MemorySubscription<T
     public EntityChange<T> Change { get; private set; } =
         new EntityChange<T>(initialEntity == null ? EntityChangeType.Delete : EntityChangeType.Update, initialEntity);
 
-    public async Task WaitForChangeAsync(TimeSpan? timeout = default, CancellationToken cancellationToken = default)
+    public async Task WaitForChangeAsync(
+        TimeSpan? timeout = null,
+        IReadOnlySet<EntityChangeType>? changeTypes = null,
+        CancellationToken cancellationToken = default
+    )
     {
         timeout ??= Timeout.InfiniteTimeSpan;
         await TaskTimeout(_changeEvent.WaitAsync, timeout.Value, cancellationToken).ConfigureAwait(false);

--- a/src/DataAccess/src/SIL.DataAccess/MongoDataAccessContext.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MongoDataAccessContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace SIL.DataAccess;
 
-public class MongoDataAccessContext(IMongoClient client) : DisposableBase, IMongoDataAccessContext
+public class MongoDataAccessContext(IMongoClient client) : ObjectModel.DisposableBase, IMongoDataAccessContext
 {
     private readonly IMongoClient _client = client;
     private readonly object _lock = new();

--- a/src/DataAccess/src/SIL.DataAccess/MongoSubscription.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MongoSubscription.cs
@@ -6,7 +6,7 @@ public class MongoSubscription<T>(
     Func<T, bool> filter,
     BsonTimestamp timestamp,
     T? initialEntity
-) : DisposableBase, ISubscription<T>
+) : ObjectModel.DisposableBase, ISubscription<T>
     where T : IEntity
 {
     private readonly IMongoDataAccessContext _context = context;
@@ -17,10 +17,34 @@ public class MongoSubscription<T>(
     public EntityChange<T> Change { get; private set; } =
         new EntityChange<T>(initialEntity == null ? EntityChangeType.Delete : EntityChangeType.Update, initialEntity);
 
-    public async Task WaitForChangeAsync(TimeSpan? timeout = default, CancellationToken cancellationToken = default)
+    public async Task WaitForChangeAsync(
+        TimeSpan? timeout = null,
+        IReadOnlySet<EntityChangeType>? changeTypes = null,
+        CancellationToken cancellationToken = default
+    )
     {
         Expression<Func<ChangeStreamDocument<T>, bool>> changeEventFilter;
-        if (Change.Entity is null)
+        if (changeTypes is not null && changeTypes.Count > 0)
+        {
+            HashSet<ChangeStreamOperationType> ops =
+            [
+                .. changeTypes.SelectMany<EntityChangeType, ChangeStreamOperationType>(ct =>
+                    ct switch
+                    {
+                        EntityChangeType.Insert => [ChangeStreamOperationType.Insert],
+                        EntityChangeType.Update =>
+                        [
+                            ChangeStreamOperationType.Update,
+                            ChangeStreamOperationType.Replace,
+                        ],
+                        EntityChangeType.Delete => [ChangeStreamOperationType.Delete],
+                        _ => throw new ArgumentException("No valid change types specified.", nameof(changeTypes)),
+                    }
+                ),
+            ];
+            changeEventFilter = ce => ops.Contains(ce.OperationType);
+        }
+        else if (Change.Entity is null)
         {
             changeEventFilter = ce => ce.OperationType == ChangeStreamOperationType.Insert;
         }
@@ -63,22 +87,14 @@ public class MongoSubscription<T>(
                 bool changed = false;
                 foreach (ChangeStreamDocument<T> ce in cursor.Current)
                 {
-                    EntityChangeType changeType = EntityChangeType.None;
-                    switch (ce.OperationType)
+                    EntityChangeType changeType = ce.OperationType switch
                     {
-                        case ChangeStreamOperationType.Insert:
-                            changeType = EntityChangeType.Insert;
-                            break;
-
-                        case ChangeStreamOperationType.Replace:
-                        case ChangeStreamOperationType.Update:
-                            changeType = EntityChangeType.Update;
-                            break;
-
-                        case ChangeStreamOperationType.Delete:
-                            changeType = EntityChangeType.Delete;
-                            break;
-                    }
+                        ChangeStreamOperationType.Insert => EntityChangeType.Insert,
+                        ChangeStreamOperationType.Replace or ChangeStreamOperationType.Update =>
+                            EntityChangeType.Update,
+                        ChangeStreamOperationType.Delete => EntityChangeType.Delete,
+                        _ => EntityChangeType.None,
+                    };
 
                     if (entityNotFound)
                     {

--- a/src/DataAccess/src/SIL.DataAccess/Usings.cs
+++ b/src/DataAccess/src/SIL.DataAccess/Usings.cs
@@ -17,4 +17,3 @@ global using Newtonsoft.Json;
 global using Newtonsoft.Json.Serialization;
 global using Nito.AsyncEx;
 global using SIL.DataAccess;
-global using SIL.ObjectModel;

--- a/src/Machine/src/Serval.Machine.Shared/Services/DistributedReaderWriterLock.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/DistributedReaderWriterLock.cs
@@ -83,7 +83,7 @@ public class DistributedReaderWriterLock(
                             timeout = TimeSpan.Zero;
                     }
                     if (timeout != TimeSpan.Zero)
-                        await sub.WaitForChangeAsync(timeout, cancellationToken);
+                        await sub.WaitForChangeAsync(timeout, cancellationToken: cancellationToken);
                 }
                 (acquired, expiresAt) = await TryAcquireReaderLock(lockId, resolvedLifetime, cancellationToken);
             } while (!acquired);
@@ -154,7 +154,7 @@ public class DistributedReaderWriterLock(
                             }
                         }
                         if (timeout != TimeSpan.Zero)
-                            await sub.WaitForChangeAsync(timeout, cancellationToken);
+                            await sub.WaitForChangeAsync(timeout, cancellationToken: cancellationToken);
                     }
                     (acquired, expiresAt) = await TryAcquireWriterLock(lockId, resolvedLifetime, cancellationToken);
                 } while (!acquired);

--- a/src/Serval/src/Serval.Client/Client.g.cs
+++ b/src/Serval/src/Serval.Client/Client.g.cs
@@ -2191,6 +2191,18 @@ namespace Serval.Client
         /// <exception cref="ServalApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<System.Collections.Generic.IList<TranslationBuild>> GetAllBuildsCreatedAfterAsync(System.DateTimeOffset? createdAfter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get the next build that finished after the specified date and time.
+        /// <br/>If not build has yet completed after that timestamp,
+        /// <br/>Serval will wait until a build is finished after that date and time.
+        /// </summary>
+        /// <param name="finishedAfter">The date and time in UTC that the next build should have finished after.
+        /// <br/>You should use the finished timestamp of the build previously returned when calling this endpoint.</param>
+        /// <returns>The engines</returns>
+        /// <exception cref="ServalApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<TranslationBuild> GetNextFinishedBuildAsync(System.DateTimeOffset? finishedAfter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.6.3.0 (NJsonSchema v11.5.2.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -2313,6 +2325,114 @@ namespace Serval.Client
                         {
                             string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new ServalApiException("The authenticated client cannot perform the operation.", status_, responseText_, headers_, null);
+                        }
+                        else
+                        if (status_ == 503)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ServalApiException("A necessary service is currently unavailable. Check `/health` for more details.", status_, responseText_, headers_, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ServalApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get the next build that finished after the specified date and time.
+        /// <br/>If not build has yet completed after that timestamp,
+        /// <br/>Serval will wait until a build is finished after that date and time.
+        /// </summary>
+        /// <param name="finishedAfter">The date and time in UTC that the next build should have finished after.
+        /// <br/>You should use the finished timestamp of the build previously returned when calling this endpoint.</param>
+        /// <returns>The engines</returns>
+        /// <exception cref="ServalApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<TranslationBuild> GetNextFinishedBuildAsync(System.DateTimeOffset? finishedAfter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder_.Append(_baseUrl);
+                    // Operation Path: "translation/builds/next-finished"
+                    urlBuilder_.Append("translation/builds/next-finished");
+                    urlBuilder_.Append('?');
+                    if (finishedAfter != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("finished-after")).Append('=').Append(System.Uri.EscapeDataString(finishedAfter.Value.ToString("s", System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    urlBuilder_.Length--;
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<TranslationBuild>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ServalApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 401)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ServalApiException("The client is not authenticated.", status_, responseText_, headers_, null);
+                        }
+                        else
+                        if (status_ == 403)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ServalApiException("The authenticated client cannot perform the operation.", status_, responseText_, headers_, null);
+                        }
+                        else
+                        if (status_ == 408)
+                        {
+                            string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ServalApiException("The long polling request timed out.", status_, responseText_, headers_, null);
                         }
                         else
                         if (status_ == 503)

--- a/src/Serval/src/Serval.Translation/Controllers/TranslationBuildsController.cs
+++ b/src/Serval/src/Serval.Translation/Controllers/TranslationBuildsController.cs
@@ -4,13 +4,12 @@ namespace Serval.Translation.Controllers;
 [Route("api/v{version:apiVersion}/translation/builds")]
 [OpenApiTag("Translation Engines")]
 public class TranslationBuildsController(
+    IOptionsMonitor<ApiOptions> apiOptions,
     IAuthorizationService authService,
     IBuildService buildService,
     IUrlService urlService
 ) : TranslationControllerBase(authService, urlService)
 {
-    private readonly IBuildService _buildService = buildService;
-
     /// <summary>
     /// Get all builds for your translation engines that are created after the specified date.
     /// </summary>
@@ -34,12 +33,51 @@ public class TranslationBuildsController(
         IEnumerable<Build> builds;
         if (createdAfter is null)
         {
-            builds = await _buildService.GetAllAsync(Owner, cancellationToken);
+            builds = await buildService.GetAllAsync(Owner, cancellationToken);
         }
         else
         {
-            builds = await _buildService.GetAllCreatedAfterAsync(Owner, createdAfter, cancellationToken);
+            builds = await buildService.GetAllCreatedAfterAsync(Owner, createdAfter, cancellationToken);
         }
         return builds.Select(Map);
+    }
+
+    /// <summary>
+    /// Get the next build that finished after the specified date and time.
+    /// If not build has yet completed after that timestamp,
+    /// Serval will wait until a build is finished after that date and time.
+    /// </summary>
+    /// <param name="finishedAfter">
+    /// The date and time in UTC that the next build should have finished after.
+    /// You should use the <c>finished</c> timestamp of the build previously returned when calling this endpoint.
+    /// </param>
+    /// <param name="cancellationToken"></param>
+    /// <response code="200">The engines</response>
+    /// <response code="401">The client is not authenticated.</response>
+    /// <response code="403">The authenticated client cannot perform the operation.</response>
+    /// <response code="408">The long polling request timed out.</response>
+    /// <response code="503">A necessary service is currently unavailable. Check `/health` for more details.</response>
+    [Authorize(Scopes.ReadTranslationEngines)]
+    [HttpGet("next-finished")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status408RequestTimeout)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult<TranslationBuildDto>> GetNextFinishedBuildAsync(
+        [FromQuery(Name = "finished-after")] DateTime finishedAfter,
+        CancellationToken cancellationToken
+    )
+    {
+        (_, EntityChange<Build> change) = await TaskEx.Timeout(
+            ct => buildService.GetNextFinishedBuildAsync(Owner, finishedAfter, ct),
+            apiOptions.CurrentValue.LongPollTimeout,
+            cancellationToken: cancellationToken
+        );
+        return change.Type switch
+        {
+            EntityChangeType.None => StatusCode(StatusCodes.Status408RequestTimeout),
+            _ => change.Entity is null ? StatusCode(StatusCodes.Status408RequestTimeout) : Map(change.Entity),
+        };
     }
 }

--- a/src/Serval/src/Serval.Translation/Services/BuildService.cs
+++ b/src/Serval/src/Serval.Translation/Services/BuildService.cs
@@ -50,6 +50,32 @@ public class BuildService(IRepository<Build> builds) : OwnedEntityServiceBase<Bu
         );
     }
 
+    public async Task<EntityChange<Build>> GetNextFinishedBuildAsync(
+        string owner,
+        DateTime finishedAfter,
+        CancellationToken cancellationToken = default
+    )
+    {
+        using ISubscription<Build> subscription = await Entities.SubscribeAsync(
+            b =>
+                b.Owner == owner
+                && (b.State == JobState.Completed || b.State == JobState.Canceled || b.State == JobState.Faulted)
+                && b.DateFinished > finishedAfter,
+            cancellationToken
+        );
+        EntityChange<Build> curChange = subscription.Change;
+        while (true)
+        {
+            if (curChange.Type is not EntityChangeType.None and not EntityChangeType.Delete)
+                return curChange;
+            await subscription.WaitForChangeAsync(
+                changeTypes: new HashSet<EntityChangeType> { EntityChangeType.Insert, EntityChangeType.Update },
+                cancellationToken: cancellationToken
+            );
+            curChange = subscription.Change;
+        }
+    }
+
     private async Task<EntityChange<Build>> GetNewerRevisionAsync(
         Expression<Func<Build, bool>> filter,
         long minRevision,

--- a/src/Serval/src/Serval.Translation/Services/IBuildService.cs
+++ b/src/Serval/src/Serval.Translation/Services/IBuildService.cs
@@ -25,4 +25,9 @@ public interface IBuildService
         long minRevision,
         CancellationToken cancellationToken = default
     );
+    Task<EntityChange<Build>> GetNextFinishedBuildAsync(
+        string owner,
+        DateTime finishedAfter,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Serval/test/Serval.ApiServer.IntegrationTests/ServalWebApplicationFactory.cs
+++ b/src/Serval/test/Serval.ApiServer.IntegrationTests/ServalWebApplicationFactory.cs
@@ -21,6 +21,8 @@ public class ServalWebApplicationFactory : WebApplicationFactory<Program>
                 options.Url = new MongoUrl("mongodb://localhost:27017/serval_test")
             );
 
+            services.Configure<ApiOptions>(options => options.LongPollTimeout = TimeSpan.FromSeconds(1));
+
             services.Configure<TranslationOptions>(options =>
             {
                 options.Engines =

--- a/src/Serval/test/Serval.ApiServer.IntegrationTests/TranslationEngineTests.cs
+++ b/src/Serval/test/Serval.ApiServer.IntegrationTests/TranslationEngineTests.cs
@@ -1496,6 +1496,49 @@ public class TranslationEngineTests
     }
 
     [Test]
+    [TestCase(new[] { Scopes.ReadTranslationEngines }, 200)]
+    [TestCase(new[] { Scopes.ReadTranslationEngines }, 408)]
+    [TestCase(new[] { Scopes.ReadFiles }, 403)] // Arbitrary unrelated privilege
+    public async Task GetNextFinishedBuildAsync(IEnumerable<string> scope, int expectedStatusCode)
+    {
+        TranslationBuildsClient client = _env.CreateTranslationBuildsClient(scope);
+        Build? build = new Build
+        {
+            EngineRef = ECHO_ENGINE1_ID,
+            Owner = "client1",
+            DateFinished = DateTime.UtcNow,
+            State = Shared.Contracts.JobState.Completed,
+        };
+        await _env.Builds.InsertAsync(build);
+        switch (expectedStatusCode)
+        {
+            case 200:
+                TranslationBuild result = await client.GetNextFinishedBuildAsync(DateTime.UtcNow.AddDays(-2));
+                Assert.That(result, Is.Not.Null);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result.Revision, Is.EqualTo(1));
+                    Assert.That(result.Id, Is.EqualTo(build?.Id));
+                    Assert.That(result.State, Is.EqualTo(JobState.Completed));
+                });
+                break;
+            case 403:
+            case 408:
+            {
+                ServalApiException? ex = Assert.ThrowsAsync<ServalApiException>(async () =>
+                {
+                    await client.GetNextFinishedBuildAsync(DateTime.UtcNow.AddDays(2));
+                });
+                Assert.That(ex?.StatusCode, Is.EqualTo(expectedStatusCode));
+                break;
+            }
+            default:
+                Assert.Fail("Unanticipated expectedStatusCode. Check test case for typo.");
+                break;
+        }
+    }
+
+    [Test]
     [TestCase(
         new[] { Scopes.UpdateTranslationEngines, Scopes.CreateTranslationEngines, Scopes.ReadTranslationEngines },
         201,


### PR DESCRIPTION
This PR adds an endpoint which will return the most recent build after the specified date/time, or will wait until a build is completed after that timeout (or the 40 second long polling timeout on Serval is hit).

I really wasn't sure on naming the endpoint, but can't think of a better URL/name?

I also noticed that the API Server Integration unit tests for long polling were taking the full 40 seconds to run, so I have updated the test environment to only long poll for 1 second. This saves a couple of minutes off the test run.

Fixes #869

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/884)
<!-- Reviewable:end -->
