### PR TITLE
Update Serval client version

### DIFF
--- a/samples/ApiExample/ApiExample.csproj
+++ b/samples/ApiExample/ApiExample.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Duende.AccessTokenManagement" Version="4.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.3" />
-    <PackageReference Include="Serval.Client" Version="1.13.0" />
+    <PackageReference Include="Serval.Client" Version="1.15.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Serval/src/Serval.Client/Serval.Client.csproj
+++ b/src/Serval/src/Serval.Client/Serval.Client.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
-		<Version>1.13.0</Version>
+		<Version>1.15.0</Version>
 		<Description>Client classes for Serval.</Description>
 		<RootNamespace>Serval.Client</RootNamespace>
 		<Product>Serval</Product>


### PR DESCRIPTION
Forgot to do this with the last release and Mike needs an updated version. I'm not sure about the numbers. Do we want this version to match the Serval version or move independently?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/889)
<!-- Reviewable:end -->
