### PR TITLE
Fix parent project look up logic

### DIFF
--- a/src/ServiceToolkit/src/SIL.ServiceToolkit/Services/CorpusBundle.cs
+++ b/src/ServiceToolkit/src/SIL.ServiceToolkit/Services/CorpusBundle.cs
@@ -63,6 +63,7 @@ public class CorpusBundle
 
         foreach ((string daughterLocation, ParatextProjectSettings daughterSettings) in paratextProjects)
         {
+            _settings[daughterLocation] = (daughterSettings, null, null);
             foreach ((string parentLocation, ParatextProjectSettings parentSettings) in paratextProjects)
             {
                 if (
@@ -73,10 +74,7 @@ public class CorpusBundle
                 {
                     daughterSettings.Parent = parentSettings;
                     _settings[daughterLocation] = (daughterSettings, parentLocation, parentSettings);
-                }
-                else
-                {
-                    _settings[daughterLocation] = (daughterSettings, null, null);
+                    break;
                 }
             }
         }

--- a/src/ServiceToolkit/src/SIL.ServiceToolkit/Services/ParallelCorpusService.cs
+++ b/src/ServiceToolkit/src/SIL.ServiceToolkit/Services/ParallelCorpusService.cs
@@ -111,11 +111,10 @@ public class ParallelCorpusService : IParallelCorpusService
             ) in corpusBundle.TextCorpora
         )
         {
-            foreach (CorpusFile file in files.Where(f => f.Format == FileFormat.Paratext))
+            foreach (CorpusFile file in files)
             {
-                using ZipArchive archive = ZipFile.OpenRead(file.Location);
-                ParatextProjectSettings settings = Machine.Corpora.ZipParatextProjectSettingsParser.Parse(archive);
-                if (settings.HasParent && corpusBundle.ParentOf(file.Location) == null)
+                ParatextProjectSettings? settings = corpusBundle.GetSettings(file.Location);
+                if (settings != null && settings.HasParent && settings.Parent == null)
                 {
                     errors.Add(
                         (

--- a/src/ServiceToolkit/test/SIL.ServiceToolkit.Tests/Services/CorpusBundleTests.cs
+++ b/src/ServiceToolkit/test/SIL.ServiceToolkit.Tests/Services/CorpusBundleTests.cs
@@ -8,11 +8,19 @@ public class CorpusBundleTests
     public void GetSettings()
     {
         using TestEnvironment env = new(addParatext: true, addText: false);
-        string fileLocation = env.CorpusBundle.ParallelCorpora[0].SourceCorpora[0].Files[0].Location;
-        ParatextProjectSettings? settings = env.CorpusBundle.GetSettings(fileLocation);
-        Assert.That(settings, Is.Not.Null);
-        Assert.That(settings.Name, Is.EqualTo("Te1"));
-        Assert.That(env.CorpusBundle.ParentOf(fileLocation), Is.Null);
+        string sourceFileLocation = env.CorpusBundle.ParallelCorpora[0].SourceCorpora[0].Files[0].Location;
+        ParatextProjectSettings? sourceSettings = env.CorpusBundle.GetSettings(sourceFileLocation);
+        Assert.That(sourceSettings, Is.Not.Null);
+        Assert.That(sourceSettings.Name, Is.EqualTo("Te1"));
+        Assert.That(env.CorpusBundle.ParentOf(sourceFileLocation), Is.Null);
+
+        string targetFileLocation = env.CorpusBundle.ParallelCorpora[0].TargetCorpora[0].Files[0].Location;
+        ParatextProjectSettings? targetSettings = env.CorpusBundle.GetSettings(targetFileLocation);
+        Assert.That(targetSettings, Is.Not.Null);
+        Assert.That(targetSettings.Name, Is.EqualTo("Te2"));
+        (string Location, ParatextProjectSettings Settings)? parent = env.CorpusBundle.ParentOf(targetFileLocation);
+        Assert.That(parent?.Location, Is.EqualTo(sourceFileLocation));
+        Assert.That(parent?.Settings.Name, Is.EqualTo(sourceSettings.Name));
     }
 
     [Test]

--- a/src/ServiceToolkit/test/SIL.ServiceToolkit.Tests/Services/ParallelCorpusServiceTests.cs
+++ b/src/ServiceToolkit/test/SIL.ServiceToolkit.Tests/Services/ParallelCorpusServiceTests.cs
@@ -4,7 +4,7 @@ namespace SIL.ServiceToolkit.Services;
 public class ParallelCorpusServiceTests
 {
     [Test]
-    public void TestParallelCorpusAnalysis_FileFormatParatext()
+    public void AnalyzeTargetQuoteConvention_FileFormatParatext()
     {
         using var env = new TestEnvironment();
         ParallelCorpus parallelCorpus = env.GetCorpora(paratextProject: true).First();
@@ -22,7 +22,7 @@ public class ParallelCorpusServiceTests
     }
 
     [Test]
-    public void TestParallelCorpusAnalysis_FileFormatText()
+    public void AnalyzeTargetQuoteConvention_FileFormatText()
     {
         using var env = new TestEnvironment();
         ParallelCorpus parallelCorpus = env.GetCorpora(paratextProject: false).First();
@@ -39,7 +39,7 @@ public class ParallelCorpusServiceTests
     }
 
     [Test]
-    public async Task TestPreprocess_FileFormatText()
+    public async Task Preprocess_FileFormatText()
     {
         using var env = new TestEnvironment();
         IReadOnlyList<ParallelCorpus> corpora = env.GetCorpora(paratextProject: false);
@@ -111,6 +111,51 @@ public class ParallelCorpusServiceTests
             Assert.That(trainCount, Is.EqualTo(5));
             Assert.That(inferenceCount, Is.EqualTo(16));
         });
+    }
+
+    [Test]
+    public void FindMissingParentProjects()
+    {
+        using var env = new TestEnvironment();
+        ParallelCorpus parallelCorpus = env.GetCorpora(paratextProject: true).First();
+
+        IReadOnlyList<(string ParallelCorpusId, string MonolingualCorpusId, MissingParentProjectError error)> errors =
+            env.Processor.FindMissingParentProjects([parallelCorpus]);
+
+        Assert.That(errors, Has.Count.EqualTo(0));
+    }
+
+    [Test]
+    public void FindMissingParentProjects_MissingParent()
+    {
+        using var env = new TestEnvironment();
+        ParallelCorpus parallelCorpus = env.GetCorpora(paratextProject: true).Last();
+
+        IReadOnlyList<(string ParallelCorpusId, string MonolingualCorpusId, MissingParentProjectError Error)> errors =
+            env.Processor.FindMissingParentProjects([parallelCorpus]);
+
+        Assert.That(errors, Has.Count.EqualTo(1));
+        Assert.That(errors[0].Error.ProjectName, Is.EqualTo("Te2"));
+        Assert.That(errors[0].Error.ParentProjectName, Is.EqualTo("Te1"));
+    }
+
+    [Test]
+    public void AnalyzeUsfmVersification()
+    {
+        using var env = new TestEnvironment();
+        ParallelCorpus parallelCorpus = env.GetCorpora(paratextProject: true).First();
+
+        IReadOnlyList<(
+            string ParallelCorpusId,
+            string MonolingualCorpusId,
+            IReadOnlyList<UsfmVersificationError> UsfmErrors
+        )> errors = env.Processor.AnalyzeUsfmVersification([parallelCorpus]);
+
+        Assert.That(errors, Has.Count.EqualTo(1));
+        Assert.That(errors[0].UsfmErrors, Has.Count.EqualTo(3));
+        Assert.That(errors[0].UsfmErrors[0].Type, Is.EqualTo(UsfmVersificationErrorType.MissingVerse));
+        Assert.That(errors[0].UsfmErrors[0].Type, Is.EqualTo(UsfmVersificationErrorType.MissingVerse));
+        Assert.That(errors[0].UsfmErrors[0].Type, Is.EqualTo(UsfmVersificationErrorType.MissingVerse));
     }
 
     private class TestEnvironment : DisposableBase
@@ -198,6 +243,29 @@ public class ParallelCorpusServiceTests
                             new MonolingualCorpus
                             {
                                 Id = "pt-target1",
+                                Language = "en",
+                                Files =
+                                [
+                                    new CorpusFile
+                                    {
+                                        TextId = "textId1",
+                                        Format = FileFormat.Paratext,
+                                        Location = ZipParatextProject("pt-target1"),
+                                    },
+                                ],
+                                TrainOnTextIds = [],
+                            },
+                        ],
+                    },
+                    new ParallelCorpus
+                    {
+                        Id = "corpus3",
+                        SourceCorpora = [],
+                        TargetCorpora =
+                        [
+                            new MonolingualCorpus
+                            {
+                                Id = "pt-target2",
                                 Language = "en",
                                 Files =
                                 [

--- a/src/ServiceToolkit/test/SIL.ServiceToolkit.Tests/Services/data/pt-target1/Settings.xml
+++ b/src/ServiceToolkit/test/SIL.ServiceToolkit.Tests/Services/data/pt-target1/Settings.xml
@@ -10,7 +10,7 @@
   <Copyright />
   <NormalizationForm>NFC</NormalizationForm>
   <Name>Te2</Name>
-  <Guid>a7e0b3ce0200736062f9f810a444dbfbe64aca35</Guid>
+  <Guid>a7e0b3ce0200736062f9f810a444dbfbe64aca36</Guid>
   <DefaultFont>Charis SIL</DefaultFont>
   <DefaultFontSize>12</DefaultFontSize>
   <FontFeatures />
@@ -23,7 +23,7 @@
   <AllowReadAccess>F</AllowReadAccess>
   <AllowSharingWithSLDR>F</AllowSharingWithSLDR>
   <Visibility>Public</Visibility>
-  <TranslationInfo>Standard::</TranslationInfo>
+  <TranslationInfo>BackTranslation:Te1:a7e0b3ce0200736062f9f810a444dbfbe64aca35</TranslationInfo>
   <EncodingConverter />
   <UsfmVersion>3</UsfmVersion>
   <ParallelPassagesBooks>000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000</ParallelPassagesBooks>


### PR DESCRIPTION
I don't know how I missed this! I think I got so caught up in the refactoring that I forgot to add rigorous tests for the most essential change :dizzy_face:. Added tests to cover this case as well as a couple other things I noticed were not covered.

Fixes https://github.com/sillsdev/serval/issues/903.

I did not de-duplicate the warnings since after thinking about it more, I wasn't sure if it'd be helpful to see whether this is affecting both SF parallel corpora or just one. Unlike duplicating the versification warnings which could become sizable, this would only ever be one extra message, so I don't know that it's worth it, but I'm open to changing my mind.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/904)
<!-- Reviewable:end -->
