### PR TITLE
Update Snappier dependency of MongoDB.Driver to 1.3.1

### DIFF
--- a/src/DataAccess/src/SIL.DataAccess/SIL.DataAccess.csproj
+++ b/src/DataAccess/src/SIL.DataAccess/SIL.DataAccess.csproj
@@ -22,6 +22,8 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
 		<PackageReference Include="SIL.Core" Version="17.0.0" />
+		<!-- Vulnerable dependency of MongoDB.Driver - see https://github.com/advisories/GHSA-pggp-6c3x-2xmx -->
+		<PackageReference Include="Snappier" Version="1.3.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Currently builds are failing with the following error:

```
error NU1903: Warning As Error: Package 'Snappier' 1.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-pggp-6c3x-2xmx
```

This PR fixes that error by updating the vulnerable dependency of MongoDB.Driver (which does not yet have a version with the updated dependency reference).

See: 

 - https://github.com/advisories/GHSA-pggp-6c3x-2xmx

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/941)
<!-- Reviewable:end -->
