### PR TITLE
Update SharpCompress dependency of MongoDB.Driver to 0.48

### DIFF
--- a/src/DataAccess/src/SIL.DataAccess/SIL.DataAccess.csproj
+++ b/src/DataAccess/src/SIL.DataAccess/SIL.DataAccess.csproj
@@ -24,6 +24,8 @@
 		<PackageReference Include="SIL.Core" Version="17.0.0" />
 		<!-- Vulnerable dependency of MongoDB.Driver - see https://github.com/advisories/GHSA-pggp-6c3x-2xmx -->
 		<PackageReference Include="Snappier" Version="1.3.1" />
+		<!-- Vulnerable dependency of MongoDB.Driver - see https://github.com/advisories/GHSA-6c8g-7p36-r338 -->
+		<PackageReference Include="SharpCompress" Version="0.48.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Currently builds are failing with the following error:

```
error NU1902: Warning As Error: Package 'SharpCompress' 0.30.1 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-6c8g-7p36-r338
```

This PR fixes that error by updating the vulnerable dependency of MongoDB.Driver (which does not yet have a version with the updated dependency reference).

See: 

 - https://github.com/advisories/GHSA-6c8g-7p36-r338

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/942)
<!-- Reviewable:end -->
