### PR TITLE
Update GetNextFinishedBuild endpoint to query based on build id

### DIFF
--- a/src/DataAccess/src/SIL.DataAccess.Abstractions/IRepository.cs
+++ b/src/DataAccess/src/SIL.DataAccess.Abstractions/IRepository.cs
@@ -27,6 +27,7 @@ public interface IRepository<T>
     Task<int> DeleteAllAsync(Expression<Func<T, bool>> filter, CancellationToken cancellationToken = default);
     Task<ISubscription<T>> SubscribeAsync(
         Expression<Func<T, bool>> filter,
+        IEnumerable<(Expression<Func<T, object?>> Field, SortOrder SortOrder)>? sort = null,
         CancellationToken cancellationToken = default
     );
 }

--- a/src/DataAccess/src/SIL.DataAccess.Abstractions/SortOrder.cs
+++ b/src/DataAccess/src/SIL.DataAccess.Abstractions/SortOrder.cs
@@ -1,0 +1,7 @@
+namespace SIL.DataAccess;
+
+public enum SortOrder
+{
+    Ascending,
+    Descending,
+}

--- a/src/DataAccess/src/SIL.DataAccess/MemoryRepository.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MemoryRepository.cs
@@ -298,13 +298,33 @@ public class MemoryRepository<T> : IRepository<T>
 
     public async Task<ISubscription<T>> SubscribeAsync(
         Expression<Func<T, bool>> filter,
+        IEnumerable<(Expression<Func<T, object?>> Field, SortOrder SortOrder)>? sort = null,
         CancellationToken cancellationToken = default
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
         using (await _lock.LockAsync(cancellationToken))
         {
-            T? initialEntity = Entities.AsQueryable().FirstOrDefault(filter);
+            IQueryable<T> query = Entities.AsQueryable().Where(filter);
+            if (sort is not null && sort.Any())
+            {
+                (Expression<Func<T, object?>> firstField, SortOrder firstSortOrder) = sort.First();
+                IOrderedQueryable<T> orderedQuery =
+                    firstSortOrder == SortOrder.Ascending
+                        ? query.OrderBy(firstField)
+                        : query.OrderByDescending(firstField);
+
+                foreach ((Expression<Func<T, object?>> field, SortOrder sortOrder) in sort.Skip(1))
+                {
+                    orderedQuery =
+                        sortOrder == SortOrder.Ascending
+                            ? orderedQuery.ThenBy(field)
+                            : orderedQuery.ThenByDescending(field);
+                }
+
+                query = orderedQuery;
+            }
+            T? initialEntity = query.FirstOrDefault();
             var subscription = new MemorySubscription<T>(initialEntity, RemoveSubscription);
             _subscriptions[subscription] = filter.Compile();
             return subscription;

--- a/src/DataAccess/src/SIL.DataAccess/MongoRepository.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MongoRepository.cs
@@ -239,6 +239,7 @@ public class MongoRepository<T>(IMongoDataAccessContext context, IMongoCollectio
 
     public async Task<ISubscription<T>> SubscribeAsync(
         Expression<Func<T, bool>> filter,
+        IEnumerable<(Expression<Func<T, object?>> Field, SortOrder SortOrder)>? sort = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -253,6 +254,21 @@ public class MongoRepository<T>(IMongoDataAccessContext context, IMongoCollectio
             { "limit", 1 },
             { "singleBatch", true },
         };
+        if (sort is not null && sort.Any())
+        {
+            findCommand.Add(
+                "sort",
+                Builders<T>
+                    .Sort.Combine(
+                        sort.Select(s =>
+                            s.SortOrder == SortOrder.Ascending
+                                ? Builders<T>.Sort.Ascending(s.Field)
+                                : Builders<T>.Sort.Descending(s.Field)
+                        )
+                    )
+                    .Render(new RenderArgs<T>(_collection.DocumentSerializer, _collection.Settings.SerializerRegistry))
+            );
+        }
         BsonDocument result;
         if (_context.Session is not null)
         {

--- a/src/Machine/src/Serval.Machine.Shared/Services/DistributedReaderWriterLock.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/DistributedReaderWriterLock.cs
@@ -69,7 +69,10 @@ public class DistributedReaderWriterLock(
         (bool acquired, DateTime expiresAt) = await TryAcquireReaderLock(lockId, resolvedLifetime, cancellationToken);
         if (!acquired)
         {
-            using ISubscription<RWLock> sub = await _locks.SubscribeAsync(rwl => rwl.Id == _id, cancellationToken);
+            using ISubscription<RWLock> sub = await _locks.SubscribeAsync(
+                rwl => rwl.Id == _id,
+                cancellationToken: cancellationToken
+            );
             do
             {
                 RWLock? rwLock = sub.Change.Entity;
@@ -134,7 +137,10 @@ public class DistributedReaderWriterLock(
             );
             try
             {
-                using ISubscription<RWLock> sub = await _locks.SubscribeAsync(rwl => rwl.Id == _id, cancellationToken);
+                using ISubscription<RWLock> sub = await _locks.SubscribeAsync(
+                    rwl => rwl.Id == _id,
+                    cancellationToken: cancellationToken
+                );
                 do
                 {
                     RWLock? rwLock = sub.Change.Entity;

--- a/src/Machine/src/Serval.Machine.Shared/Services/LocalBuildJobRunner.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/LocalBuildJobRunner.cs
@@ -103,14 +103,14 @@ public class LocalBuildJobRunner(
                 e.CurrentBuild != null
                 && e.CurrentBuild.BuildJobRunner == BuildJobRunnerType.Local
                 && e.CurrentBuild.JobState == BuildJobState.Pending,
-            stoppingToken
+            cancellationToken: stoppingToken
         );
         using ISubscription<WordAlignmentEngine> wordAlignmentSub = await wordAlignmentEngines.SubscribeAsync(
             e =>
                 e.CurrentBuild != null
                 && e.CurrentBuild.BuildJobRunner == BuildJobRunnerType.Local
                 && e.CurrentBuild.JobState == BuildJobState.Pending,
-            stoppingToken
+            cancellationToken: stoppingToken
         );
 
         await RecoverPendingJobsAsync(scope.ServiceProvider, stoppingToken);

--- a/src/Serval/src/Serval.ApiServer/nswag.json
+++ b/src/Serval/src/Serval.ApiServer/nswag.json
@@ -46,7 +46,7 @@
       "generateContractsOutput": false,
       "contractsNamespace": null,
       "contractsOutputFilePath": null,
-      "parameterDateTimeFormat": "u",
+      "parameterDateTimeFormat": "o",
       "parameterDateFormat": "yyyy-MM-dd",
       "generateUpdateJsonSerializerSettingsMethod": true,
       "useRequestAndResponseSerializationSettings": false,

--- a/src/Serval/src/Serval.Client/Client.g.cs
+++ b/src/Serval/src/Serval.Client/Client.g.cs
@@ -7398,7 +7398,7 @@ namespace Serval.Client
         /// <summary>
         /// Get all builds for your translation engines that are created after the specified date.
         /// </summary>
-        /// <param name="createdAfter">The date and time in UTC that the builds were created after (optional).</param>
+        /// <param name="createdAfter">The date and time (either in UTC or with offset) that the builds were created after (optional).</param>
         /// <returns>The engines</returns>
         /// <exception cref="ServalApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<System.Collections.Generic.IList<TranslationBuild>> GetAllBuildsCreatedAfterAsync(System.DateTimeOffset? createdAfter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -7409,7 +7409,7 @@ namespace Serval.Client
         /// <br/>If not build has yet completed after that timestamp,
         /// <br/>Serval will wait until a build is finished after that date and time.
         /// </summary>
-        /// <param name="finishedAfter">The date and time in UTC that the next build should have finished after.
+        /// <param name="finishedAfter">The date and time (either in UTC or with offset) that the next build should have finished after.
         /// <br/>You should use the finished timestamp of the build previously returned when calling this endpoint.</param>
         /// <returns>The engines</returns>
         /// <exception cref="ServalApiException">A server side error occurred.</exception>
@@ -7469,7 +7469,7 @@ namespace Serval.Client
         /// <summary>
         /// Get all builds for your translation engines that are created after the specified date.
         /// </summary>
-        /// <param name="createdAfter">The date and time in UTC that the builds were created after (optional).</param>
+        /// <param name="createdAfter">The date and time (either in UTC or with offset) that the builds were created after (optional).</param>
         /// <returns>The engines</returns>
         /// <exception cref="ServalApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<System.Collections.Generic.IList<TranslationBuild>> GetAllBuildsCreatedAfterAsync(System.DateTimeOffset? createdAfter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -7490,7 +7490,7 @@ namespace Serval.Client
                     urlBuilder_.Append('?');
                     if (createdAfter != null)
                     {
-                        urlBuilder_.Append(System.Uri.EscapeDataString("created-after")).Append('=').Append(System.Uri.EscapeDataString(createdAfter.Value.ToString("u", System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                        urlBuilder_.Append(System.Uri.EscapeDataString("created-after")).Append('=').Append(System.Uri.EscapeDataString(createdAfter.Value.ToString("o", System.Globalization.CultureInfo.InvariantCulture))).Append('&');
                     }
                     urlBuilder_.Length--;
 
@@ -7570,7 +7570,7 @@ namespace Serval.Client
         /// <br/>If not build has yet completed after that timestamp,
         /// <br/>Serval will wait until a build is finished after that date and time.
         /// </summary>
-        /// <param name="finishedAfter">The date and time in UTC that the next build should have finished after.
+        /// <param name="finishedAfter">The date and time (either in UTC or with offset) that the next build should have finished after.
         /// <br/>You should use the finished timestamp of the build previously returned when calling this endpoint.</param>
         /// <returns>The engines</returns>
         /// <exception cref="ServalApiException">A server side error occurred.</exception>
@@ -7592,7 +7592,7 @@ namespace Serval.Client
                     urlBuilder_.Append('?');
                     if (finishedAfter != null)
                     {
-                        urlBuilder_.Append(System.Uri.EscapeDataString("finished-after")).Append('=').Append(System.Uri.EscapeDataString(finishedAfter.Value.ToString("u", System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                        urlBuilder_.Append(System.Uri.EscapeDataString("finished-after")).Append('=').Append(System.Uri.EscapeDataString(finishedAfter.Value.ToString("o", System.Globalization.CultureInfo.InvariantCulture))).Append('&');
                     }
                     urlBuilder_.Length--;
 

--- a/src/Serval/src/Serval.Client/Client.g.cs
+++ b/src/Serval/src/Serval.Client/Client.g.cs
@@ -7405,15 +7405,14 @@ namespace Serval.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get the next build that finished after the specified date and time.
-        /// <br/>If not build has yet completed after that timestamp,
-        /// <br/>Serval will wait until a build is finished after that date and time.
+        /// Get the next build that finishes after the specified build id.
+        /// <br/>If no build has yet completed after that id, or you do not specify the id,
+        /// <br/>Serval will wait until the next build is finished.
         /// </summary>
-        /// <param name="finishedAfter">The date and time (either in UTC or with offset) that the next build should have finished after.
-        /// <br/>You should use the finished timestamp of the build previously returned when calling this endpoint.</param>
-        /// <returns>The engines</returns>
+        /// <param name="finishedAfter">The id of the build that the next build must finish after (optional)</param>
+        /// <returns>The build</returns>
         /// <exception cref="ServalApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<TranslationBuild> GetNextFinishedBuildAsync(System.DateTimeOffset? finishedAfter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<TranslationBuild> GetNextFinishedBuildAsync(string? finishedAfter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
     }
 
@@ -7566,15 +7565,14 @@ namespace Serval.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get the next build that finished after the specified date and time.
-        /// <br/>If not build has yet completed after that timestamp,
-        /// <br/>Serval will wait until a build is finished after that date and time.
+        /// Get the next build that finishes after the specified build id.
+        /// <br/>If no build has yet completed after that id, or you do not specify the id,
+        /// <br/>Serval will wait until the next build is finished.
         /// </summary>
-        /// <param name="finishedAfter">The date and time (either in UTC or with offset) that the next build should have finished after.
-        /// <br/>You should use the finished timestamp of the build previously returned when calling this endpoint.</param>
-        /// <returns>The engines</returns>
+        /// <param name="finishedAfter">The id of the build that the next build must finish after (optional)</param>
+        /// <returns>The build</returns>
         /// <exception cref="ServalApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<TranslationBuild> GetNextFinishedBuildAsync(System.DateTimeOffset? finishedAfter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<TranslationBuild> GetNextFinishedBuildAsync(string? finishedAfter = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -7592,7 +7590,7 @@ namespace Serval.Client
                     urlBuilder_.Append('?');
                     if (finishedAfter != null)
                     {
-                        urlBuilder_.Append(System.Uri.EscapeDataString("finished-after")).Append('=').Append(System.Uri.EscapeDataString(finishedAfter.Value.ToString("o", System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                        urlBuilder_.Append(System.Uri.EscapeDataString("finished-after")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(finishedAfter, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
                     }
                     urlBuilder_.Length--;
 

--- a/src/Serval/src/Serval.Translation/Configuration/IServalConfiguratorExtensions.cs
+++ b/src/Serval/src/Serval.Translation/Configuration/IServalConfiguratorExtensions.cs
@@ -84,6 +84,10 @@ public static class IServalConfiguratorExtensions
                         .Merge(c, new MergeStageOptions<Build> { WhenMatched = MergeStageWhenMatched.Replace })
                         .ToListAsync(),
                 MongoMigrations.MigrateTargetQuoteConvention,
+                c =>
+                    c.Indexes.CreateOrUpdateAsync(
+                        new CreateIndexModel<Build>(Builders<Build>.IndexKeys.Ascending(b => b.DateFinished))
+                    ),
             ]
         );
         configurator.DataAccess.AddRepository<Pretranslation>(

--- a/src/Serval/src/Serval.Translation/Features/Builds/GetAllBuildsCreatedAfter.cs
+++ b/src/Serval/src/Serval.Translation/Features/Builds/GetAllBuildsCreatedAfter.cs
@@ -38,7 +38,9 @@ public partial class TranslationBuildsController
     /// <summary>
     /// Get all builds for your translation engines that are created after the specified date.
     /// </summary>
-    /// <param name="createdAfter">The date and time in UTC that the builds were created after (optional).</param>
+    /// <param name="createdAfter">
+    /// The date and time (either in UTC or with offset) that the builds were created after (optional).
+    /// </param>
     /// <param name="cancellationToken"></param>
     /// <response code="200">The engines</response>
     /// <response code="401">The client is not authenticated.</response>

--- a/src/Serval/src/Serval.Translation/Features/Builds/GetNextFinishedBuild.cs
+++ b/src/Serval/src/Serval.Translation/Features/Builds/GetNextFinishedBuild.cs
@@ -66,7 +66,7 @@ public partial class TranslationBuildsController
     /// Serval will wait until a build is finished after that date and time.
     /// </summary>
     /// <param name="finishedAfter">
-    /// The date and time in UTC that the next build should have finished after.
+    /// The date and time (either in UTC or with offset) that the next build should have finished after.
     /// You should use the <c>finished</c> timestamp of the build previously returned when calling this endpoint.
     /// </param>
     /// <param name="cancellationToken"></param>

--- a/src/Serval/src/Serval.Translation/Features/Builds/GetNextFinishedBuild.cs
+++ b/src/Serval/src/Serval.Translation/Features/Builds/GetNextFinishedBuild.cs
@@ -1,6 +1,6 @@
 namespace Serval.Translation.Features.Builds;
 
-public record GetNextFinishedBuild(string Owner, DateTime FinishedAfter) : IRequest<GetNextFinishedBuildResponse>;
+public record GetNextFinishedBuild(string Owner, string? Id = null) : IRequest<GetNextFinishedBuildResponse>;
 
 public record GetNextFinishedBuildResponse(
     [property: MemberNotNullWhen(false, nameof(Build))] bool TimedOut,
@@ -18,10 +18,14 @@ public class GetNextFinishedBuildHandler(
         CancellationToken cancellationToken = default
     )
     {
-        DateTime finishedAfter =
-            request.FinishedAfter.Kind == DateTimeKind.Unspecified
-                ? DateTime.SpecifyKind(request.FinishedAfter, DateTimeKind.Utc)
-                : request.FinishedAfter.ToUniversalTime();
+        DateTime dateFinished = DateTime.UtcNow;
+        string? id = request.Id;
+        if (id is not null)
+        {
+            Build? build = await builds.GetAsync(id, cancellationToken);
+            if (build is not null)
+                dateFinished = build.DateFinished ?? DateTime.UtcNow;
+        }
 
         (_, EntityChange<Build> change) = await TaskEx.Timeout(
             async ct =>
@@ -32,7 +36,10 @@ public class GetNextFinishedBuildHandler(
                         && (
                             b.State == JobState.Completed || b.State == JobState.Canceled || b.State == JobState.Faulted
                         )
-                        && b.DateFinished > finishedAfter,
+                        && (
+                            b.DateFinished > dateFinished || (b.DateFinished == dateFinished && b.Id.CompareTo(id) > 0)
+                        ),
+                    [(b => b.DateFinished, SortOrder.Ascending), (b => b.Id, SortOrder.Ascending)],
                     ct
                 );
                 EntityChange<Build> curChange = subscription.Change;
@@ -61,16 +68,13 @@ public class GetNextFinishedBuildHandler(
 public partial class TranslationBuildsController
 {
     /// <summary>
-    /// Get the next build that finished after the specified date and time.
-    /// If not build has yet completed after that timestamp,
-    /// Serval will wait until a build is finished after that date and time.
+    /// Get the next build that finishes after the specified build id.
+    /// If no build has yet completed after that id, or you do not specify the id,
+    /// Serval will wait until the next build is finished.
     /// </summary>
-    /// <param name="finishedAfter">
-    /// The date and time (either in UTC or with offset) that the next build should have finished after.
-    /// You should use the <c>finished</c> timestamp of the build previously returned when calling this endpoint.
-    /// </param>
+    /// <param name="finishedAfter">The id of the build that the next build must finish after (optional)</param>
     /// <param name="cancellationToken"></param>
-    /// <response code="200">The engines</response>
+    /// <response code="200">The build</response>
     /// <response code="401">The client is not authenticated.</response>
     /// <response code="403">The authenticated client cannot perform the operation.</response>
     /// <response code="408">The long polling request timed out.</response>
@@ -83,7 +87,7 @@ public partial class TranslationBuildsController
     [ProducesResponseType(typeof(void), StatusCodes.Status408RequestTimeout)]
     [ProducesResponseType(typeof(void), StatusCodes.Status503ServiceUnavailable)]
     public async Task<ActionResult<TranslationBuildDto>> GetNextFinishedBuildAsync(
-        [FromQuery(Name = "finished-after")] DateTime finishedAfter,
+        [FromQuery(Name = "finished-after")] string? finishedAfter,
         [FromServices] IRequestHandler<GetNextFinishedBuild, GetNextFinishedBuildResponse> handler,
         CancellationToken cancellationToken
     )

--- a/src/Serval/src/Serval.Translation/Features/Engines/BuildRepositoryExtensions.cs
+++ b/src/Serval/src/Serval.Translation/Features/Engines/BuildRepositoryExtensions.cs
@@ -9,7 +9,10 @@ internal static class BuildRepositoryExtensions
         CancellationToken cancellationToken = default
     )
     {
-        using ISubscription<Build> subscription = await repository.SubscribeAsync(filter, cancellationToken);
+        using ISubscription<Build> subscription = await repository.SubscribeAsync(
+            filter,
+            cancellationToken: cancellationToken
+        );
         EntityChange<Build> curChange = subscription.Change;
         if (curChange.Type == EntityChangeType.Delete && minRevision > 1)
             return curChange;

--- a/src/Serval/src/Serval.WordAlignment/Services/BuildService.cs
+++ b/src/Serval/src/Serval.WordAlignment/Services/BuildService.cs
@@ -43,7 +43,10 @@ public class BuildService(IRepository<Build> builds) : EntityServiceBase<Build>(
         CancellationToken cancellationToken = default
     )
     {
-        using ISubscription<Build> subscription = await Entities.SubscribeAsync(filter, cancellationToken);
+        using ISubscription<Build> subscription = await Entities.SubscribeAsync(
+            filter,
+            cancellationToken: cancellationToken
+        );
         EntityChange<Build> curChange = subscription.Change;
         if (curChange.Type == EntityChangeType.Delete && minRevision > 1)
             return curChange;

--- a/src/Serval/test/Serval.ApiServer.IntegrationTests/TranslationEngineTests.cs
+++ b/src/Serval/test/Serval.ApiServer.IntegrationTests/TranslationEngineTests.cs
@@ -90,6 +90,7 @@ public class TranslationEngineTests
     private const string TARGET_CORPUS_ID = "cc0000000000000000000004";
     private const string TARGET_CORPUS_ID_PT = "cc0000000000000000000005";
     private const string EMPTY_CORPUS_ID = "cc0000000000000000000006";
+    private const string BUILD1_ID = "b00000000000000000000001";
 
     private const string DOES_NOT_EXIST_ENGINE_ID = "e00000000000000000000004";
     private const string DOES_NOT_EXIST_CORPUS_ID = "c00000000000000000000001";
@@ -1470,29 +1471,43 @@ public class TranslationEngineTests
     }
 
     [Test]
-    [TestCase(new[] { Scopes.ReadTranslationEngines }, 200)]
-    [TestCase(new[] { Scopes.ReadTranslationEngines }, 408)]
-    [TestCase(new[] { Scopes.ReadFiles }, 403)] // Arbitrary unrelated privilege
-    public async Task GetNextFinishedBuildAsync(IEnumerable<string> scope, int expectedStatusCode)
+    [TestCase(new[] { Scopes.ReadTranslationEngines }, 200, null)]
+    [TestCase(new[] { Scopes.ReadTranslationEngines }, 200, BUILD1_ID)]
+    [TestCase(new[] { Scopes.ReadTranslationEngines }, 408, null)]
+    [TestCase(new[] { Scopes.ReadFiles }, 403, null)] // Arbitrary unrelated privilege
+    public async Task GetNextFinishedBuildAsync(
+        IEnumerable<string> scope,
+        int expectedStatusCode,
+        string? finishedAfter
+    )
     {
         TranslationBuildsClient client = _env.CreateTranslationBuildsClient(scope);
-        Build? build = new Build
+        Build? build1 = new Build
         {
+            Id = BUILD1_ID,
             EngineRef = ECHO_ENGINE1_ID,
             Owner = "client1",
-            DateFinished = DateTime.UtcNow,
+            DateFinished = DateTime.UtcNow.AddHours(expectedStatusCode == 408 ? -1 : 1),
             State = Shared.Contracts.JobState.Completed,
         };
-        await _env.Builds.InsertAsync(build);
+        await _env.Builds.InsertAsync(build1);
+        Build? build2 = new Build
+        {
+            EngineRef = ECHO_ENGINE2_ID,
+            Owner = "client1",
+            DateFinished = DateTime.UtcNow.AddHours(expectedStatusCode == 408 ? -2 : 2),
+            State = Shared.Contracts.JobState.Completed,
+        };
+        await _env.Builds.InsertAsync(build2);
         switch (expectedStatusCode)
         {
             case 200:
-                TranslationBuild result = await client.GetNextFinishedBuildAsync(DateTime.UtcNow.AddDays(-2));
+                TranslationBuild result = await client.GetNextFinishedBuildAsync(finishedAfter);
                 Assert.That(result, Is.Not.Null);
                 Assert.Multiple(() =>
                 {
                     Assert.That(result.Revision, Is.EqualTo(1));
-                    Assert.That(result.Id, Is.EqualTo(build?.Id));
+                    Assert.That(result.Id, Is.EqualTo((finishedAfter is null ? build1 : build2)?.Id));
                     Assert.That(result.State, Is.EqualTo(Client.JobState.Completed));
                 });
                 break;
@@ -1501,7 +1516,7 @@ public class TranslationEngineTests
             {
                 ServalApiException? ex = Assert.ThrowsAsync<ServalApiException>(async () =>
                 {
-                    await client.GetNextFinishedBuildAsync(DateTime.UtcNow.AddDays(2));
+                    await client.GetNextFinishedBuildAsync(finishedAfter);
                 });
                 Assert.That(ex?.StatusCode, Is.EqualTo(expectedStatusCode));
                 break;
@@ -1952,15 +1967,13 @@ public class TranslationEngineTests
     )
     {
         TranslationEnginesClient client = _env.CreateTranslationEnginesClient(scope);
-
-        string buildId = "b00000000000000000000000";
         if (addBuild)
         {
             _env.EchoService.CancelBuildAsync(engineId, Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult<string?>(buildId));
+                .Returns(Task.FromResult<string?>(BUILD1_ID));
             var build = new Build
             {
-                Id = buildId,
+                Id = BUILD1_ID,
                 EngineRef = engineId,
                 Owner = "client1",
             };
@@ -1971,7 +1984,7 @@ public class TranslationEngineTests
         {
             case 200:
                 TranslationBuild build = await client.CancelBuildAsync(engineId);
-                Assert.That(build.Id, Is.EqualTo("b00000000000000000000000"));
+                Assert.That(build.Id, Is.EqualTo(BUILD1_ID));
                 break;
             case 204:
             case 403:
@@ -2266,7 +2279,7 @@ public class TranslationEngineTests
         await _env.Builds.InsertAsync(
             new Build
             {
-                Id = "b10000000000000000000000",
+                Id = BUILD1_ID,
                 EngineRef = ECHO_ENGINE1_ID,
                 Owner = "client1",
                 Revision = 1,
@@ -2358,7 +2371,7 @@ public class TranslationEngineTests
         await _env.Builds.InsertAsync(
             new Build
             {
-                Id = "b10000000000000000000000",
+                Id = BUILD1_ID,
                 EngineRef = ECHO_ENGINE1_ID,
                 Owner = "client1",
                 Revision = 1,

--- a/src/Serval/test/Serval.Translation.Tests/Features/Builds/BuildsHandlersTests.cs
+++ b/src/Serval/test/Serval.Translation.Tests/Features/Builds/BuildsHandlersTests.cs
@@ -4,6 +4,7 @@ namespace Serval.Translation.Features.Builds;
 public class BuildsHandlersTests
 {
     const string BUILD1_ID = "b00000000000000000000001";
+    const string BUILD2_ID = "b00000000000000000000002";
 
     [Test]
     public async Task GetAllBuildsCreatedAfter_NoFilter_Success()
@@ -91,11 +92,46 @@ public class BuildsHandlersTests
     }
 
     [Test]
+    public async Task GetNextFinishedBuild_FinishedAtSameTime()
+    {
+        TestEnvironment env = new();
+        DateTime dateFinished = DateTime.UtcNow;
+        await env.Builds.InsertAsync(
+            new()
+            {
+                Id = BUILD1_ID,
+                EngineRef = "engine1",
+                Owner = "user1",
+                State = JobState.Completed,
+                DateFinished = dateFinished,
+            }
+        );
+        await env.Builds.InsertAsync(
+            new()
+            {
+                Id = BUILD2_ID,
+                EngineRef = "engine1",
+                Owner = "user1",
+                State = JobState.Completed,
+                DateFinished = dateFinished,
+            }
+        );
+        GetNextFinishedBuildHandler handler = new(env.Builds, env.DtoMapper, env.ApiOptions);
+        GetNextFinishedBuildResponse response = await handler.HandleAsync(new("user1", BUILD1_ID));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response.TimedOut, Is.False);
+            Assert.That(response.Build?.Id, Is.EqualTo(BUILD2_ID));
+            Assert.That(response.Build?.State, Is.EqualTo(JobState.Completed));
+        }
+    }
+
+    [Test]
     public async Task GetNextFinishedBuild_Insert()
     {
         TestEnvironment env = new();
         GetNextFinishedBuildHandler handler = new(env.Builds, env.DtoMapper, env.ApiOptions);
-        Task<GetNextFinishedBuildResponse> task = handler.HandleAsync(new("user1", DateTime.UtcNow.AddMinutes(-1)));
+        Task<GetNextFinishedBuildResponse> task = handler.HandleAsync(new("user1", null));
 
         await env.Builds.InsertAsync(
             new()
@@ -116,6 +152,40 @@ public class BuildsHandlersTests
     }
 
     [Test]
+    public async Task GetNextFinishedBuild_PreviousBuild()
+    {
+        TestEnvironment env = new();
+        await env.Builds.InsertAsync(
+            new()
+            {
+                Id = BUILD2_ID,
+                EngineRef = "engine1",
+                Owner = "user1",
+                State = JobState.Completed,
+                DateFinished = DateTime.UtcNow.AddMinutes(-2),
+            }
+        );
+        await env.Builds.InsertAsync(
+            new()
+            {
+                Id = BUILD1_ID,
+                EngineRef = "engine1",
+                Owner = "user1",
+                State = JobState.Completed,
+                DateFinished = DateTime.UtcNow,
+            }
+        );
+        GetNextFinishedBuildHandler handler = new(env.Builds, env.DtoMapper, env.ApiOptions);
+        GetNextFinishedBuildResponse response = await handler.HandleAsync(new("user1", BUILD2_ID));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response.TimedOut, Is.False);
+            Assert.That(response.Build?.Id, Is.EqualTo(BUILD1_ID));
+            Assert.That(response.Build?.State, Is.EqualTo(JobState.Completed));
+        }
+    }
+
+    [Test]
     public async Task GetNextFinishedBuild_Update()
     {
         TestEnvironment env = new();
@@ -128,7 +198,7 @@ public class BuildsHandlersTests
         await env.Builds.InsertAsync(build);
 
         GetNextFinishedBuildHandler handler = new(env.Builds, env.DtoMapper, env.ApiOptions);
-        Task<GetNextFinishedBuildResponse> task = handler.HandleAsync(new("user1", DateTime.UtcNow.AddMinutes(-1)));
+        Task<GetNextFinishedBuildResponse> task = handler.HandleAsync(new("user1", null));
 
         await env.Builds.UpdateAsync(
             build,


### PR DESCRIPTION
This PR fixes a bug I noticed where the date time values passed to the `GetAllBuildsCreatedAfterAsync` endpoint were missing millisecond values, and so the same build was being returned each time.

I also updated the method documentation to remove the outdated only in UTC requirement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/952)
<!-- Reviewable:end -->
