### PR TITLE
Use one cursor per subscription

### DIFF
--- a/src/DataAccess/src/SIL.DataAccess.Abstractions/IRepository.cs
+++ b/src/DataAccess/src/SIL.DataAccess.Abstractions/IRepository.cs
@@ -28,6 +28,7 @@ public interface IRepository<T>
     Task<ISubscription<T>> SubscribeAsync(
         Expression<Func<T, bool>> filter,
         IEnumerable<(Expression<Func<T, object?>> Field, SortOrder SortOrder)>? sort = null,
+        IReadOnlySet<EntityChangeType>? changeTypes = null,
         CancellationToken cancellationToken = default
     );
 }

--- a/src/DataAccess/src/SIL.DataAccess.Abstractions/IRepository.cs
+++ b/src/DataAccess/src/SIL.DataAccess.Abstractions/IRepository.cs
@@ -28,7 +28,7 @@ public interface IRepository<T>
     Task<ISubscription<T>> SubscribeAsync(
         Expression<Func<T, bool>> filter,
         IEnumerable<(Expression<Func<T, object?>> Field, SortOrder SortOrder)>? sort = null,
-        IReadOnlySet<EntityChangeType>? changeTypes = null,
+        SubscriptionMode mode = SubscriptionMode.Entity,
         CancellationToken cancellationToken = default
     );
 }

--- a/src/DataAccess/src/SIL.DataAccess.Abstractions/ISubscription.cs
+++ b/src/DataAccess/src/SIL.DataAccess.Abstractions/ISubscription.cs
@@ -4,9 +4,6 @@ public interface ISubscription<T> : IDisposable
     where T : IEntity
 {
     EntityChange<T> Change { get; }
-    Task WaitForChangeAsync(
-        TimeSpan? timeout = null,
-        IReadOnlySet<EntityChangeType>? changeTypes = null,
-        CancellationToken cancellationToken = default
-    );
+    Task WaitForChangeAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+    DateTime Timestamp { get; }
 }

--- a/src/DataAccess/src/SIL.DataAccess.Abstractions/ISubscription.cs
+++ b/src/DataAccess/src/SIL.DataAccess.Abstractions/ISubscription.cs
@@ -5,5 +5,4 @@ public interface ISubscription<T> : IDisposable
 {
     EntityChange<T> Change { get; }
     Task WaitForChangeAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default);
-    DateTime Timestamp { get; }
 }

--- a/src/DataAccess/src/SIL.DataAccess.Abstractions/SubscriptionMode.cs
+++ b/src/DataAccess/src/SIL.DataAccess.Abstractions/SubscriptionMode.cs
@@ -1,0 +1,8 @@
+namespace SIL.DataAccess;
+
+public enum SubscriptionMode
+{
+    Entity,
+
+    Repository,
+}

--- a/src/DataAccess/src/SIL.DataAccess/MemoryRepository.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MemoryRepository.cs
@@ -299,7 +299,7 @@ public class MemoryRepository<T> : IRepository<T>
     public async Task<ISubscription<T>> SubscribeAsync(
         Expression<Func<T, bool>> filter,
         IEnumerable<(Expression<Func<T, object?>> Field, SortOrder SortOrder)>? sort = null,
-        IReadOnlySet<EntityChangeType>? changeTypes = null,
+        SubscriptionMode mode = SubscriptionMode.Entity,
         CancellationToken cancellationToken = default
     )
     {

--- a/src/DataAccess/src/SIL.DataAccess/MemoryRepository.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MemoryRepository.cs
@@ -299,6 +299,7 @@ public class MemoryRepository<T> : IRepository<T>
     public async Task<ISubscription<T>> SubscribeAsync(
         Expression<Func<T, bool>> filter,
         IEnumerable<(Expression<Func<T, object?>> Field, SortOrder SortOrder)>? sort = null,
+        IReadOnlySet<EntityChangeType>? changeTypes = null,
         CancellationToken cancellationToken = default
     )
     {

--- a/src/DataAccess/src/SIL.DataAccess/MemorySubscription.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MemorySubscription.cs
@@ -8,17 +8,15 @@ public class MemorySubscription<T>(T? initialEntity, Action<MemorySubscription<T
     private readonly Action<MemorySubscription<T>> _remove = remove;
     private readonly AsyncAutoResetEvent _changeEvent = new();
 
+    public DateTime Timestamp { get; private set; } = DateTime.UnixEpoch;
+
     public EntityChange<T> Change { get; private set; } =
         new EntityChange<T>(initialEntity == null ? EntityChangeType.Delete : EntityChangeType.Update, initialEntity);
 
-    public async Task WaitForChangeAsync(
-        TimeSpan? timeout = null,
-        IReadOnlySet<EntityChangeType>? changeTypes = null,
-        CancellationToken cancellationToken = default
-    )
+    public async Task WaitForChangeAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
-        timeout ??= Timeout.InfiniteTimeSpan;
-        await TaskTimeout(_changeEvent.WaitAsync, timeout.Value, cancellationToken).ConfigureAwait(false);
+        await TaskTimeout(_changeEvent.WaitAsync, timeout ?? Timeout.InfiniteTimeSpan, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     internal void HandleChange(EntityChange<T> change)

--- a/src/DataAccess/src/SIL.DataAccess/MemorySubscription.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MemorySubscription.cs
@@ -8,8 +8,6 @@ public class MemorySubscription<T>(T? initialEntity, Action<MemorySubscription<T
     private readonly Action<MemorySubscription<T>> _remove = remove;
     private readonly AsyncAutoResetEvent _changeEvent = new();
 
-    public DateTime Timestamp { get; private set; } = DateTime.UnixEpoch;
-
     public EntityChange<T> Change { get; private set; } =
         new EntityChange<T>(initialEntity == null ? EntityChangeType.Delete : EntityChangeType.Update, initialEntity);
 

--- a/src/DataAccess/src/SIL.DataAccess/MongoRepository.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MongoRepository.cs
@@ -240,7 +240,7 @@ public class MongoRepository<T>(IMongoDataAccessContext context, IMongoCollectio
     public async Task<ISubscription<T>> SubscribeAsync(
         Expression<Func<T, bool>> filter,
         IEnumerable<(Expression<Func<T, object?>> Field, SortOrder SortOrder)>? sort = null,
-        IReadOnlySet<EntityChangeType>? changeTypes = null,
+        SubscriptionMode mode = SubscriptionMode.Entity,
         CancellationToken cancellationToken = default
     )
     {
@@ -296,7 +296,7 @@ public class MongoRepository<T>(IMongoDataAccessContext context, IMongoCollectio
             filter.Compile(),
             timestamp,
             initialEntity,
-            changeTypes
+            mode
         );
         return subscription;
     }

--- a/src/DataAccess/src/SIL.DataAccess/MongoRepository.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MongoRepository.cs
@@ -240,6 +240,7 @@ public class MongoRepository<T>(IMongoDataAccessContext context, IMongoCollectio
     public async Task<ISubscription<T>> SubscribeAsync(
         Expression<Func<T, bool>> filter,
         IEnumerable<(Expression<Func<T, object?>> Field, SortOrder SortOrder)>? sort = null,
+        IReadOnlySet<EntityChangeType>? changeTypes = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -289,7 +290,14 @@ public class MongoRepository<T>(IMongoDataAccessContext context, IMongoCollectio
         BsonDocument? initialEntityDoc = result["cursor"]["firstBatch"].AsBsonArray.FirstOrDefault()?.AsBsonDocument;
         T? initialEntity = initialEntityDoc is null ? default : BsonSerializer.Deserialize<T>(initialEntityDoc);
         var timestamp = (BsonTimestamp)result["operationTime"];
-        var subscription = new MongoSubscription<T>(_context, _collection, filter.Compile(), timestamp, initialEntity);
+        var subscription = new MongoSubscription<T>(
+            _context,
+            _collection,
+            filter.Compile(),
+            timestamp,
+            initialEntity,
+            changeTypes
+        );
         return subscription;
     }
 

--- a/src/DataAccess/src/SIL.DataAccess/MongoSubscription.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MongoSubscription.cs
@@ -9,8 +9,8 @@ public class MongoSubscription<T> : ObjectModel.DisposableBase, ISubscription<T>
     private readonly Func<T, bool> _filter;
     private IChangeStreamCursor<ChangeStreamDocument<T>>? _cursor;
     private readonly Expression<Func<ChangeStreamDocument<T>, bool>> _changeEventFilter;
-    public DateTime Timestamp => DateTime.UnixEpoch.AddSeconds(_timestamp.Timestamp);
-
+    private TimeSpan? _timeout;
+    private BsonDocument? _resumeToken;
     public EntityChange<T> Change { get; private set; }
 
     public MongoSubscription(
@@ -19,7 +19,7 @@ public class MongoSubscription<T> : ObjectModel.DisposableBase, ISubscription<T>
         Func<T, bool> filter,
         BsonTimestamp timestamp,
         T? initialEntity,
-        IReadOnlySet<EntityChangeType>? changeTypes = null
+        SubscriptionMode mode = SubscriptionMode.Repository
     )
     {
         _context = context;
@@ -31,25 +31,15 @@ public class MongoSubscription<T> : ObjectModel.DisposableBase, ISubscription<T>
             initialEntity
         );
         Expression<Func<ChangeStreamDocument<T>, bool>> changeEventFilter;
-        if (changeTypes is not null && changeTypes.Count > 0)
+        if (mode == SubscriptionMode.Repository)
         {
-            HashSet<ChangeStreamOperationType> ops =
-            [
-                .. changeTypes.SelectMany<EntityChangeType, ChangeStreamOperationType>(ct =>
-                    ct switch
-                    {
-                        EntityChangeType.Insert => [ChangeStreamOperationType.Insert],
-                        EntityChangeType.Update =>
-                        [
-                            ChangeStreamOperationType.Update,
-                            ChangeStreamOperationType.Replace,
-                        ],
-                        EntityChangeType.Delete => [ChangeStreamOperationType.Delete],
-                        _ => throw new ArgumentException("No valid change types specified.", nameof(changeTypes)),
-                    }
-                ),
-            ];
-            changeEventFilter = ce => ops.Contains(ce.OperationType);
+            changeEventFilter = ce =>
+                new HashSet<ChangeStreamOperationType>
+                {
+                    ChangeStreamOperationType.Insert,
+                    ChangeStreamOperationType.Update,
+                    ChangeStreamOperationType.Replace,
+                }.Contains(ce.OperationType);
         }
         else if (Change.Entity is null)
         {
@@ -69,14 +59,23 @@ public class MongoSubscription<T> : ObjectModel.DisposableBase, ISubscription<T>
 
     public async Task WaitForChangeAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
-        if (_cursor is null)
+        if (_cursor is null || !timeout.Equals(_timeout))
         {
+            _cursor?.Dispose();
+            _timeout = timeout;
             var options = new ChangeStreamOptions
             {
                 FullDocument = ChangeStreamFullDocumentOption.UpdateLookup,
-                MaxAwaitTime = timeout,
-                StartAtOperationTime = _timestamp,
+                MaxAwaitTime = _timeout,
             };
+            if (_resumeToken is not null)
+            {
+                options.ResumeAfter = _resumeToken;
+            }
+            else
+            {
+                options.StartAtOperationTime = _timestamp;
+            }
             PipelineDefinition<ChangeStreamDocument<T>, ChangeStreamDocument<T>> pipelineDef = PipelineDefinitionBuilder
                 .For<ChangeStreamDocument<T>>()
                 .Match(_changeEventFilter);
@@ -94,42 +93,62 @@ public class MongoSubscription<T> : ObjectModel.DisposableBase, ISubscription<T>
 
         DateTime started = DateTime.UtcNow;
 
-        while (await _cursor.MoveNextAsync(cancellationToken).ConfigureAwait(false))
+        try
         {
-            bool entityNotFound = Change.Entity is null;
-            bool changed = false;
-            foreach (ChangeStreamDocument<T> ce in _cursor.Current)
+            while (await _cursor.MoveNextAsync(cancellationToken).ConfigureAwait(false))
             {
-                EntityChangeType changeType = ce.OperationType switch
+                bool entityNotFound = Change.Entity is null;
+                bool changed = false;
+                foreach (ChangeStreamDocument<T> ce in _cursor.Current)
                 {
-                    ChangeStreamOperationType.Insert => EntityChangeType.Insert,
-                    ChangeStreamOperationType.Replace or ChangeStreamOperationType.Update => EntityChangeType.Update,
-                    ChangeStreamOperationType.Delete => EntityChangeType.Delete,
-                    _ => EntityChangeType.None,
-                };
+                    _timestamp = ce.ClusterTime;
+                    _resumeToken = ce.ResumeToken;
 
-                if (entityNotFound)
-                {
-                    if (ce.FullDocument is not null && _filter(ce.FullDocument))
+                    if (
+                        ce.FullDocument is not null
+                        && Change.Entity is not null
+                        && ce.FullDocument.Equals(Change.Entity)
+                    )
+                    {
+                        continue;
+                    }
+
+                    EntityChangeType changeType = ce.OperationType switch
+                    {
+                        ChangeStreamOperationType.Insert => EntityChangeType.Insert,
+                        ChangeStreamOperationType.Replace or ChangeStreamOperationType.Update =>
+                            EntityChangeType.Update,
+                        ChangeStreamOperationType.Delete => EntityChangeType.Delete,
+                        _ => EntityChangeType.None,
+                    };
+
+                    if (entityNotFound)
+                    {
+                        if (ce.FullDocument is not null && _filter(ce.FullDocument))
+                        {
+                            Change = new EntityChange<T>(changeType, ce.FullDocument);
+                            changed = true;
+                        }
+                    }
+                    else
                     {
                         Change = new EntityChange<T>(changeType, ce.FullDocument);
                         changed = true;
                     }
                 }
-                else
-                {
-                    Change = new EntityChange<T>(changeType, ce.FullDocument);
-                    changed = true;
-                }
 
-                _timestamp = ce.ClusterTime;
+                if (changed)
+                    return;
+
+                if (timeout.HasValue && DateTime.UtcNow - started >= timeout)
+                    return;
             }
-
-            if (changed)
-                return;
-
-            if (timeout.HasValue && DateTime.UtcNow - started >= timeout)
-                return;
+        }
+        catch (MongoException)
+        {
+            _cursor?.Dispose();
+            _cursor = null;
+            throw;
         }
     }
 

--- a/src/DataAccess/src/SIL.DataAccess/MongoSubscription.cs
+++ b/src/DataAccess/src/SIL.DataAccess/MongoSubscription.cs
@@ -1,28 +1,35 @@
 ﻿namespace SIL.DataAccess;
 
-public class MongoSubscription<T>(
-    IMongoDataAccessContext context,
-    IMongoCollection<T> entities,
-    Func<T, bool> filter,
-    BsonTimestamp timestamp,
-    T? initialEntity
-) : ObjectModel.DisposableBase, ISubscription<T>
+public class MongoSubscription<T> : ObjectModel.DisposableBase, ISubscription<T>
     where T : IEntity
 {
-    private readonly IMongoDataAccessContext _context = context;
-    private readonly IMongoCollection<T> _entities = entities;
-    private BsonTimestamp _timestamp = timestamp;
-    private readonly Func<T, bool> _filter = filter;
+    private readonly IMongoDataAccessContext _context;
+    private readonly IMongoCollection<T> _entities;
+    private BsonTimestamp _timestamp;
+    private readonly Func<T, bool> _filter;
+    private IChangeStreamCursor<ChangeStreamDocument<T>>? _cursor;
+    private readonly Expression<Func<ChangeStreamDocument<T>, bool>> _changeEventFilter;
+    public DateTime Timestamp => DateTime.UnixEpoch.AddSeconds(_timestamp.Timestamp);
 
-    public EntityChange<T> Change { get; private set; } =
-        new EntityChange<T>(initialEntity == null ? EntityChangeType.Delete : EntityChangeType.Update, initialEntity);
+    public EntityChange<T> Change { get; private set; }
 
-    public async Task WaitForChangeAsync(
-        TimeSpan? timeout = null,
-        IReadOnlySet<EntityChangeType>? changeTypes = null,
-        CancellationToken cancellationToken = default
+    public MongoSubscription(
+        IMongoDataAccessContext context,
+        IMongoCollection<T> entities,
+        Func<T, bool> filter,
+        BsonTimestamp timestamp,
+        T? initialEntity,
+        IReadOnlySet<EntityChangeType>? changeTypes = null
     )
     {
+        _context = context;
+        _entities = entities;
+        _timestamp = timestamp;
+        _filter = filter;
+        Change = new EntityChange<T>(
+            initialEntity == null ? EntityChangeType.Delete : EntityChangeType.Update,
+            initialEntity
+        );
         Expression<Func<ChangeStreamDocument<T>, bool>> changeEventFilter;
         if (changeTypes is not null && changeTypes.Count > 0)
         {
@@ -57,72 +64,77 @@ public class MongoSubscription<T>(
                     || ce.FullDocument.Revision > Change.Entity.Revision
                 );
         }
-        var options = new ChangeStreamOptions
-        {
-            FullDocument = ChangeStreamFullDocumentOption.UpdateLookup,
-            MaxAwaitTime = timeout,
-            StartAtOperationTime = _timestamp,
-        };
-        PipelineDefinition<ChangeStreamDocument<T>, ChangeStreamDocument<T>> pipelineDef = PipelineDefinitionBuilder
-            .For<ChangeStreamDocument<T>>()
-            .Match(changeEventFilter);
-        IChangeStreamCursor<ChangeStreamDocument<T>> cursor;
-        if (_context.Session is not null)
-        {
-            cursor = await _entities
-                .WatchAsync(_context.Session, pipelineDef, options, cancellationToken)
-                .ConfigureAwait(false);
-        }
-        else
-        {
-            cursor = await _entities.WatchAsync(pipelineDef, options, cancellationToken).ConfigureAwait(false);
-        }
-        try
-        {
-            DateTime started = DateTime.UtcNow;
+        _changeEventFilter = changeEventFilter;
+    }
 
-            while (await cursor.MoveNextAsync(cancellationToken).ConfigureAwait(false))
+    public async Task WaitForChangeAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    {
+        if (_cursor is null)
+        {
+            var options = new ChangeStreamOptions
             {
-                bool entityNotFound = Change.Entity is null;
-                bool changed = false;
-                foreach (ChangeStreamDocument<T> ce in cursor.Current)
-                {
-                    EntityChangeType changeType = ce.OperationType switch
-                    {
-                        ChangeStreamOperationType.Insert => EntityChangeType.Insert,
-                        ChangeStreamOperationType.Replace or ChangeStreamOperationType.Update =>
-                            EntityChangeType.Update,
-                        ChangeStreamOperationType.Delete => EntityChangeType.Delete,
-                        _ => EntityChangeType.None,
-                    };
+                FullDocument = ChangeStreamFullDocumentOption.UpdateLookup,
+                MaxAwaitTime = timeout,
+                StartAtOperationTime = _timestamp,
+            };
+            PipelineDefinition<ChangeStreamDocument<T>, ChangeStreamDocument<T>> pipelineDef = PipelineDefinitionBuilder
+                .For<ChangeStreamDocument<T>>()
+                .Match(_changeEventFilter);
+            if (_context.Session is not null)
+            {
+                _cursor = await _entities
+                    .WatchAsync(_context.Session, pipelineDef, options, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                _cursor = await _entities.WatchAsync(pipelineDef, options, cancellationToken).ConfigureAwait(false);
+            }
+        }
 
-                    if (entityNotFound)
-                    {
-                        if (ce.FullDocument is not null && _filter(ce.FullDocument))
-                        {
-                            Change = new EntityChange<T>(changeType, ce.FullDocument);
-                            changed = true;
-                        }
-                    }
-                    else
+        DateTime started = DateTime.UtcNow;
+
+        while (await _cursor.MoveNextAsync(cancellationToken).ConfigureAwait(false))
+        {
+            bool entityNotFound = Change.Entity is null;
+            bool changed = false;
+            foreach (ChangeStreamDocument<T> ce in _cursor.Current)
+            {
+                EntityChangeType changeType = ce.OperationType switch
+                {
+                    ChangeStreamOperationType.Insert => EntityChangeType.Insert,
+                    ChangeStreamOperationType.Replace or ChangeStreamOperationType.Update => EntityChangeType.Update,
+                    ChangeStreamOperationType.Delete => EntityChangeType.Delete,
+                    _ => EntityChangeType.None,
+                };
+
+                if (entityNotFound)
+                {
+                    if (ce.FullDocument is not null && _filter(ce.FullDocument))
                     {
                         Change = new EntityChange<T>(changeType, ce.FullDocument);
                         changed = true;
                     }
-
-                    _timestamp = ce.ClusterTime;
+                }
+                else
+                {
+                    Change = new EntityChange<T>(changeType, ce.FullDocument);
+                    changed = true;
                 }
 
-                if (changed)
-                    return;
-
-                if (timeout.HasValue && DateTime.UtcNow - started >= timeout)
-                    return;
+                _timestamp = ce.ClusterTime;
             }
+
+            if (changed)
+                return;
+
+            if (timeout.HasValue && DateTime.UtcNow - started >= timeout)
+                return;
         }
-        finally
-        {
-            cursor.Dispose();
-        }
+    }
+
+    protected override void DisposeManagedResources()
+    {
+        _cursor?.Dispose();
     }
 }

--- a/src/Machine/src/Serval.Machine.Shared/Services/LocalBuildJobRunner.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/LocalBuildJobRunner.cs
@@ -103,6 +103,7 @@ public class LocalBuildJobRunner(
                 e.CurrentBuild != null
                 && e.CurrentBuild.BuildJobRunner == BuildJobRunnerType.Local
                 && e.CurrentBuild.JobState == BuildJobState.Pending,
+            changeTypes: new HashSet<EntityChangeType> { EntityChangeType.Insert, EntityChangeType.Update },
             cancellationToken: stoppingToken
         );
         using ISubscription<WordAlignmentEngine> wordAlignmentSub = await wordAlignmentEngines.SubscribeAsync(
@@ -110,6 +111,7 @@ public class LocalBuildJobRunner(
                 e.CurrentBuild != null
                 && e.CurrentBuild.BuildJobRunner == BuildJobRunnerType.Local
                 && e.CurrentBuild.JobState == BuildJobState.Pending,
+            changeTypes: new HashSet<EntityChangeType> { EntityChangeType.Insert, EntityChangeType.Update },
             cancellationToken: stoppingToken
         );
 
@@ -227,42 +229,43 @@ public class LocalBuildJobRunner(
     {
         while (!cancellationToken.IsCancellationRequested)
         {
-            EntityChange<TEngine> change = subscription.Change;
-            if (change.Type is EntityChangeType.Insert or EntityChangeType.Update && change.Entity != null)
-            {
-                TEngine engine = change.Entity;
-                Build? build = engine.CurrentBuild;
-                if (
-                    build?.BuildJobRunner == BuildJobRunnerType.Local
-                    && build.JobState == BuildJobState.Pending
-                    && !_activeCts.ContainsKey(build.JobId)
-                    && _pendingJobs.TryAdd(
-                        build.JobId,
-                        new JobInfo(
-                            engine.EngineId,
-                            build.BuildId,
-                            engine.Type,
-                            build.Stage,
-                            build.JobData,
-                            build.Options
-                        )
-                    )
-                )
-                {
-                    _jobChannels[engineGroup].Writer.TryWrite(build.JobId);
-                }
-            }
-
             try
             {
-                await subscription.WaitForChangeAsync(
-                    changeTypes: new HashSet<EntityChangeType> { EntityChangeType.Insert, EntityChangeType.Update },
-                    cancellationToken: cancellationToken
-                );
+                EntityChange<TEngine> change = subscription.Change;
+                if (change.Type is EntityChangeType.Insert or EntityChangeType.Update && change.Entity != null)
+                {
+                    TEngine engine = change.Entity;
+                    Build? build = engine.CurrentBuild;
+                    if (
+                        build?.BuildJobRunner == BuildJobRunnerType.Local
+                        && build.JobState == BuildJobState.Pending
+                        && !_activeCts.ContainsKey(build.JobId)
+                        && _pendingJobs.TryAdd(
+                            build.JobId,
+                            new JobInfo(
+                                engine.EngineId,
+                                build.BuildId,
+                                engine.Type,
+                                build.Stage,
+                                build.JobData,
+                                build.Options
+                            )
+                        )
+                    )
+                    {
+                        _jobChannels[engineGroup].Writer.TryWrite(build.JobId);
+                    }
+                }
+                await subscription.WaitForChangeAsync(cancellationToken: cancellationToken);
             }
             catch (OperationCanceledException)
             {
                 break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unhandled exception while watching {EngineGroup} engines.", engineGroup);
+                throw;
             }
         }
     }

--- a/src/Machine/src/Serval.Machine.Shared/Services/LocalBuildJobRunner.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/LocalBuildJobRunner.cs
@@ -103,7 +103,7 @@ public class LocalBuildJobRunner(
                 e.CurrentBuild != null
                 && e.CurrentBuild.BuildJobRunner == BuildJobRunnerType.Local
                 && e.CurrentBuild.JobState == BuildJobState.Pending,
-            changeTypes: new HashSet<EntityChangeType> { EntityChangeType.Insert, EntityChangeType.Update },
+            mode: SubscriptionMode.Repository,
             cancellationToken: stoppingToken
         );
         using ISubscription<WordAlignmentEngine> wordAlignmentSub = await wordAlignmentEngines.SubscribeAsync(
@@ -111,7 +111,7 @@ public class LocalBuildJobRunner(
                 e.CurrentBuild != null
                 && e.CurrentBuild.BuildJobRunner == BuildJobRunnerType.Local
                 && e.CurrentBuild.JobState == BuildJobState.Pending,
-            changeTypes: new HashSet<EntityChangeType> { EntityChangeType.Insert, EntityChangeType.Update },
+            mode: SubscriptionMode.Repository,
             cancellationToken: stoppingToken
         );
 

--- a/src/Serval/src/Serval.Translation/Features/Builds/GetNextFinishedBuild.cs
+++ b/src/Serval/src/Serval.Translation/Features/Builds/GetNextFinishedBuild.cs
@@ -40,6 +40,7 @@ public class GetNextFinishedBuildHandler(
                             b.DateFinished > dateFinished || (b.DateFinished == dateFinished && b.Id.CompareTo(id) > 0)
                         ),
                     [(b => b.DateFinished, SortOrder.Ascending), (b => b.Id, SortOrder.Ascending)],
+                    new HashSet<EntityChangeType> { EntityChangeType.Insert, EntityChangeType.Update },
                     ct
                 );
                 EntityChange<Build> curChange = subscription.Change;
@@ -47,10 +48,7 @@ public class GetNextFinishedBuildHandler(
                 {
                     if (curChange.Type is not EntityChangeType.None and not EntityChangeType.Delete)
                         return curChange;
-                    await subscription.WaitForChangeAsync(
-                        changeTypes: new HashSet<EntityChangeType> { EntityChangeType.Insert, EntityChangeType.Update },
-                        cancellationToken: ct
-                    );
+                    await subscription.WaitForChangeAsync(cancellationToken: ct);
                     curChange = subscription.Change;
                 }
             },

--- a/src/Serval/src/Serval.Translation/Features/Builds/GetNextFinishedBuild.cs
+++ b/src/Serval/src/Serval.Translation/Features/Builds/GetNextFinishedBuild.cs
@@ -40,7 +40,7 @@ public class GetNextFinishedBuildHandler(
                             b.DateFinished > dateFinished || (b.DateFinished == dateFinished && b.Id.CompareTo(id) > 0)
                         ),
                     [(b => b.DateFinished, SortOrder.Ascending), (b => b.Id, SortOrder.Ascending)],
-                    new HashSet<EntityChangeType> { EntityChangeType.Insert, EntityChangeType.Update },
+                    SubscriptionMode.Repository,
                     ct
                 );
                 EntityChange<Build> curChange = subscription.Change;


### PR DESCRIPTION
This addresses a problem we've been receiving alerts about from Atlas where thousands of documents were being scanned but only a few returned. I think this is a problem we've actually hit in the past as well without realizing that this was the source of the problem. 

As I mentioned in the thread on Slack, because we use the `StartAfterOperationTime` based on the cluster time of the last change event (which is only precise down to the second), we can sometimes get stuck in a loop where we keep reprocessing the same update. This will not happen if we keep a single long-running cursor (or if we used a resume token). If the collection goes a long time without an update and we're stuck on an update like this, we end up having to scan the oplog over and over scanning days of changes because the timestamp that governs the `StartAfterOperationTime` never gets updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/954)
<!-- Reviewable:end -->
