### PR TITLE
Save alignment scores for pre-translations

### DIFF
--- a/src/Machine/src/Serval.Machine.Shared/Services/ServalTranslationPlatformService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/ServalTranslationPlatformService.cs
@@ -145,6 +145,7 @@ public class ServalTranslationPlatformService(ITranslationPlatformService platfo
                     {
                         SourceIndex = a.SourceIndex,
                         TargetIndex = a.TargetIndex,
+                        Score = a.AlignmentScore,
                     }),
                 ],
                 Confidence = pretranslation.Confidence,

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/ServalTranslationPlatformServiceTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/ServalTranslationPlatformServiceTests.cs
@@ -102,7 +102,15 @@ public class ServalTranslationPlatformServiceTests
                         Translation = "translation",
                         SourceTokens = ["sourceToken1"],
                         TranslationTokens = ["translationToken1"],
-                        Alignment = [new AlignedWordPairContract { SourceIndex = 0, TargetIndex = 0 }],
+                        Alignment =
+                        [
+                            new AlignedWordPairContract
+                            {
+                                SourceIndex = 0,
+                                TargetIndex = 0,
+                                Score = -1,
+                            },
+                        ],
                         Confidence = 0.0,
                     }
                 )

--- a/src/Serval/src/Serval.Translation/Services/PlatformService.cs
+++ b/src/Serval/src/Serval.Translation/Services/PlatformService.cs
@@ -395,6 +395,7 @@ public class PlatformService(
                         {
                             SourceIndex = a.SourceIndex,
                             TargetIndex = a.TargetIndex,
+                            Score = a.Score,
                         })
                         .ToList(),
                     Confidence = item.Confidence,


### PR DESCRIPTION
Partial fix for #948.

The machine.py PR still needs to be completed, but this change is backwards compatible with the current version of machine.py.

One thing which will be different is currently the `score` value for pre-translations is written as 0, however, after this PR is merged, they will be written as -1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/962)
<!-- Reviewable:end -->
