### PR TITLE
Remove the hangfire dashboard

### DIFF
--- a/src/Serval/src/Serval.ApiServer/Startup.cs
+++ b/src/Serval/src/Serval.ApiServer/Startup.cs
@@ -173,11 +173,7 @@ public class Startup(IConfiguration configuration, IWebHostEnvironment environme
         app.UseRequestTimeouts();
         app.UseOutputCache();
         app.UseAuthorization();
-        app.UseEndpoints(x =>
-        {
-            x.MapControllers();
-            x.MapHangfireDashboard();
-        });
+        app.UseEndpoints(x => x.MapControllers());
 
         app.UseOpenApi(o =>
         {

--- a/src/Serval/src/Serval.ApiServer/Usings.cs
+++ b/src/Serval/src/Serval.ApiServer/Usings.cs
@@ -5,7 +5,6 @@ global using System.Security.Claims;
 global using System.Text.Json.Serialization;
 global using Asp.Versioning;
 global using Bugsnag.AspNet.Core;
-global using Hangfire;
 global using Microsoft.AspNetCore.Authentication.JwtBearer;
 global using Microsoft.AspNetCore.Authorization;
 global using Microsoft.AspNetCore.Http.Timeouts;


### PR DESCRIPTION
Fixes #970.

I decided that just removing the dashboard was better than implementing an authorization filter, as the dashboard currently isn't accessible via Docker or Kubernetes anyway, and Hangfire is currently only used for the webhook, which will be removed after the next release of Scripture Forge stops requiring a webhook.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/983)
<!-- Reviewable:end -->
