### PR TITLE
Encode build_options in base64

### DIFF
--- a/src/Machine/src/Serval.Machine.Translation/Services/NmtClearMLBuildJobFactory.cs
+++ b/src/Machine/src/Serval.Machine.Translation/Services/NmtClearMLBuildJobFactory.cs
@@ -41,7 +41,11 @@ public class NmtClearMLBuildJobFactory(
                 + $"    'trg_lang': '{trgLang}',\n"
                 + $"    'shared_file_uri': '{baseUri}',\n"
                 + $"    'shared_file_folder': '{folder}',\n"
-                + (buildOptions is not null ? $"    'build_options': '''{buildOptions}''',\n" : "")
+                + (
+                    buildOptions is not null
+                        ? $"    'build_options': '''{Convert.ToBase64String(Encoding.UTF8.GetBytes(buildOptions))}''',\n"
+                        : ""
+                )
                 // buildRevision + 1 because the build revision is incremented after the build job
                 // is finished successfully but the file should be saved with the new revision number
                 + (engine.IsModelPersisted ? $"    'save_model': '{engineId}_{engine.BuildRevision + 1}',\n" : $"")

--- a/src/Machine/src/Serval.Machine.Translation/Services/SmtTransferClearMLBuildJobFactory.cs
+++ b/src/Machine/src/Serval.Machine.Translation/Services/SmtTransferClearMLBuildJobFactory.cs
@@ -35,7 +35,11 @@ public class SmtTransferClearMLBuildJobFactory(
                 + $"    'build_id': '{buildId}',\n"
                 + $"    'shared_file_uri': '{baseUri}',\n"
                 + $"    'shared_file_folder': '{folder}',\n"
-                + (buildOptions is not null ? $"    'build_options': '''{buildOptions}''',\n" : "")
+                + (
+                    buildOptions is not null
+                        ? $"    'build_options': '''{Convert.ToBase64String(Encoding.UTF8.GetBytes(buildOptions))}''',\n"
+                        : ""
+                )
                 + $"    'clearml': True\n"
                 + "}\n"
                 + "run(args)\n";

--- a/src/Machine/src/Serval.Machine.Translation/Usings.cs
+++ b/src/Machine/src/Serval.Machine.Translation/Usings.cs
@@ -4,6 +4,7 @@ global using System.Diagnostics.CodeAnalysis;
 global using System.IO.Compression;
 global using System.Reflection;
 global using System.Runtime.CompilerServices;
+global using System.Text;
 global using System.Text.Json;
 global using System.Text.Json.Nodes;
 global using System.Text.Json.Serialization;

--- a/src/Machine/src/Serval.Machine.WordAlignment/Services/StatisticalClearMLBuildJobFactory.cs
+++ b/src/Machine/src/Serval.Machine.WordAlignment/Services/StatisticalClearMLBuildJobFactory.cs
@@ -35,7 +35,11 @@ public class StatisticalClearMLBuildJobFactory(
                 + $"    'build_id': '{buildId}',\n"
                 + $"    'shared_file_uri': '{baseUri}',\n"
                 + $"    'shared_file_folder': '{folder}',\n"
-                + (buildOptions is not null ? $"    'build_options': '''{buildOptions}''',\n" : "")
+                + (
+                    buildOptions is not null
+                        ? $"    'build_options': '''{Convert.ToBase64String(Encoding.UTF8.GetBytes(buildOptions))}''',\n"
+                        : ""
+                )
                 + $"    'clearml': True\n"
                 + "}\n"
                 + "run(args)\n";

--- a/src/Machine/src/Serval.Machine.WordAlignment/Usings.cs
+++ b/src/Machine/src/Serval.Machine.WordAlignment/Usings.cs
@@ -2,6 +2,7 @@ global using System.Collections.Concurrent;
 global using System.IO.Compression;
 global using System.Reflection;
 global using System.Runtime.CompilerServices;
+global using System.Text;
 global using System.Text.Json;
 global using System.Text.Json.Nodes;
 global using System.Text.Json.Serialization;

--- a/src/Machine/test/Serval.Machine.Translation.Tests/Services/NmtClearMLBuildJobFactoryTests.cs
+++ b/src/Machine/test/Serval.Machine.Translation.Tests/Services/NmtClearMLBuildJobFactoryTests.cs
@@ -7,18 +7,20 @@ public class NmtClearMLBuildJobFactoryTests
     public async Task CreateJobScriptAsync_BuildOptions()
     {
         var env = new TestEnvironment();
+        const string BuildOptions = "{ \"max_steps\": \"10\" }";
+        string buildOptionsBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(BuildOptions));
         string script = await env.BuildJobFactory.CreateJobScriptAsync(
             "engine1",
             "build1",
             "test_model",
             BuildStage.Train,
-            buildOptions: "{ \"max_steps\": \"10\" }"
+            buildOptions: BuildOptions
         );
         Assert.That(
             script,
             Is.EqualTo(
-                @"from machine.jobs.build_nmt_engine import run
-args = {
+                $@"from machine.jobs.build_nmt_engine import run
+args = {{
     'model_type': 'test_model',
     'engine_id': 'engine1',
     'build_id': 'build1',
@@ -26,9 +28,9 @@ args = {
     'trg_lang': 'eng_Latn',
     'shared_file_uri': 's3://bucket',
     'shared_file_folder': 'folder1/folder2',
-    'build_options': '''{ ""max_steps"": ""10"" }''',
+    'build_options': '''{buildOptionsBase64}''',
     'clearml': True
-}
+}}
 run(args)
 ".ReplaceLineEndings("\n")
             )

--- a/src/Machine/test/Serval.Machine.Translation.Tests/Usings.cs
+++ b/src/Machine/test/Serval.Machine.Translation.Tests/Usings.cs
@@ -1,4 +1,5 @@
-﻿global using System.Text.Json;
+﻿global using System.Text;
+global using System.Text.Json;
 global using System.Text.Json.Nodes;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Logging;


### PR DESCRIPTION
Partial fix for https://github.com/sillsdev/serval/issues/966.

Requires: https://github.com/sillsdev/machine.py/pull/330.

I will implement build_option constraints separately in another PR, as those will be implemented at the API boundary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/992)
<!-- Reviewable:end -->
