### PR TITLE
Use the geometric mean for build-level confidence

### DIFF
--- a/src/Serval/src/Serval.Translation/Services/PlatformService.cs
+++ b/src/Serval/src/Serval.Translation/Services/PlatformService.cs
@@ -431,7 +431,10 @@ public class PlatformService(
             u =>
                 u.Set(
                     b => b.ExecutionData.AveragePretranslationConfidence,
-                    confidenceCount > 0 ? Math.Exp(logConfidenceTotal / confidenceCount) : 0.0
+                    // Calculate the geometric mean of the pretranslation confidences
+                    confidenceCount > 0
+                        ? Math.Exp(logConfidenceTotal / confidenceCount)
+                        : 0.0
                 ),
             cancellationToken: cancellationToken
         );

--- a/src/Serval/src/Serval.Translation/Services/PlatformService.cs
+++ b/src/Serval/src/Serval.Translation/Services/PlatformService.cs
@@ -380,7 +380,8 @@ public class PlatformService(
         int nextModelRevision = engine.ModelRevision + 1;
 
         var batch = new List<Pretranslation>();
-        double totalConfidence = 0.0;
+        double logConfidenceTotal = 0.0;
+        int confidenceCount = 0;
         int numPretranslations = 0;
         await foreach (PretranslationContract item in pretranslations.WithCancellation(cancellationToken))
         {
@@ -408,8 +409,14 @@ public class PlatformService(
                     Confidence = item.Confidence,
                 }
             );
-            totalConfidence += item.Confidence ?? 0.0;
-            numPretranslations += 1;
+            double? confidence = item.Confidence;
+            if (confidence != null && confidence > 0.0)
+            {
+                logConfidenceTotal += Math.Log((double)confidence);
+                confidenceCount++;
+            }
+
+            numPretranslations++;
             if (batch.Count == PretranslationInsertBatchSize)
             {
                 await _pretranslations.InsertAllAsync(batch, cancellationToken);
@@ -424,7 +431,7 @@ public class PlatformService(
             u =>
                 u.Set(
                     b => b.ExecutionData.AveragePretranslationConfidence,
-                    numPretranslations > 0 ? totalConfidence / numPretranslations : 0.0
+                    confidenceCount > 0 ? Math.Exp(logConfidenceTotal / confidenceCount) : 0.0
                 ),
             cancellationToken: cancellationToken
         );

--- a/src/Serval/test/Serval.Translation.Tests/Services/PlatformServiceTests.cs
+++ b/src/Serval/test/Serval.Translation.Tests/Services/PlatformServiceTests.cs
@@ -77,6 +77,44 @@ public class PlatformServiceTests
     }
 
     [Test]
+    public async Task BuildCompletedAsync_AveragePretranslationConfidence()
+    {
+        var env = new TestEnvironment();
+        await env.Engines.InsertAsync(
+            new Engine()
+            {
+                Id = "e0",
+                Owner = "owner1",
+                Type = "nmt",
+                SourceLanguage = "en",
+                TargetLanguage = "es",
+                Corpora = [],
+            }
+        );
+        await env.Builds.InsertAsync(
+            new Build()
+            {
+                Id = "b0",
+                EngineRef = "e0",
+                Owner = "owner1",
+            }
+        );
+
+        await env.PlatformService.BuildStartedAsync("b0");
+        await env.PlatformService.InsertPretranslationsAsync(
+            "e0",
+            "b0",
+            GetTestPretranslationsWithConfidences([0.25, 0.5, 1.0])
+        );
+        await env.PlatformService.BuildCompletedAsync("b0", 0, 0.0);
+
+        Assert.That(
+            (await env.Builds.GetAsync(b => b.Id == "b0"))?.ExecutionData.AveragePretranslationConfidence,
+            Is.EqualTo(0.5).Within(0.0001)
+        );
+    }
+
+    [Test]
     public async Task UpdateBuildStatusAsync()
     {
         var env = new TestEnvironment();
@@ -340,6 +378,29 @@ public class PlatformServiceTests
             TranslationTokens = [],
             Alignment = [],
         };
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<PretranslationContract> GetTestPretranslationsWithConfidences(
+        IReadOnlyList<double> confidences
+    )
+    {
+        for (int index = 0; index < confidences.Count; index++)
+        {
+            yield return new PretranslationContract
+            {
+                CorpusId = "e0",
+                TextId = $"text{index}",
+                SourceRefs = [$"ref{index}"],
+                TargetRefs = [$"ref{index}"],
+                Translation = "test",
+                SourceTokens = [],
+                TranslationTokens = [],
+                Alignment = [],
+                Confidence = confidences[index],
+            };
+        }
+
         await Task.CompletedTask;
     }
 


### PR DESCRIPTION
After our discussion yesterday, I realized that the research team had been using the geometric mean for aggregating segment confidences, so we probably ought to too. This average does still include non-Scripture. If we want to exclude non-Scripture, we might consider either adding an additional field or renaming it to specify that it's an average only for verses. As a high-level stat, I don't think it's inappropriate for it to include all translation confidences, but I'm happy to filter them out if we decide it's best.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/1004)
<!-- Reviewable:end -->
