### PR TITLE
Throw a 409 status code when starting a build and one is already running

### DIFF
--- a/src/Machine/src/Serval.Machine.Shared/Services/EchoTranslationEngineService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/EchoTranslationEngineService.cs
@@ -87,7 +87,7 @@ public class EchoTranslationEngineService(
         );
         // If there is a pending/running build, then no need to start a new one.
         if (building)
-            await platformService.BuildCanceledAsync(buildId, CancellationToken.None);
+            throw new ConflictException();
     }
 
     public Task<string?> CancelBuildAsync(string engineId, CancellationToken cancellationToken = default) =>

--- a/src/Machine/src/Serval.Machine.Shared/Services/EchoWordAlignmentEngineService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/EchoWordAlignmentEngineService.cs
@@ -89,7 +89,7 @@ public class EchoWordAlignmentEngineService(
         );
         // If there is a pending/running build, then no need to start a new one.
         if (building)
-            await platformService.BuildCanceledAsync(buildId, CancellationToken.None);
+            throw new ConflictException();
     }
 
     public Task<string?> CancelBuildAsync(string engineId, CancellationToken cancellationToken = default) =>

--- a/src/Machine/src/Serval.Machine.Shared/Services/NmtEngineService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/NmtEngineService.cs
@@ -100,7 +100,7 @@ public class NmtEngineService(
         );
         // If there is a pending/running build, then no need to start a new one.
         if (building)
-            await _platformService.BuildCanceledAsync(buildId, CancellationToken.None);
+            throw new ConflictException();
     }
 
     public Task<string?> CancelBuildAsync(string engineId, CancellationToken cancellationToken = default)

--- a/src/Machine/src/Serval.Machine.Shared/Services/SmtTransferEngineService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/SmtTransferEngineService.cs
@@ -199,7 +199,7 @@ public class SmtTransferEngineService(
         );
         // If there is a pending/running build, then no need to start a new one.
         if (building)
-            await _platformService.BuildCanceledAsync(buildId, CancellationToken.None);
+            throw new ConflictException();
 
         SmtTransferEngineState state = _stateService.Get(engineId);
         state.Touch();

--- a/src/Machine/src/Serval.Machine.Shared/Services/StatisticalEngineService.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/StatisticalEngineService.cs
@@ -125,7 +125,7 @@ public class StatisticalEngineService(
         );
         // If there is a pending/running build, then no need to start a new one.
         if (building)
-            await _platformService.BuildCanceledAsync(buildId, CancellationToken.None);
+            throw new ConflictException();
 
         StatisticalEngineState state = _stateService.Get(engineId);
         state.Touch();

--- a/src/Machine/test/Serval.Machine.Shared.Tests/Services/EchoWordAlignmentEngineServiceTests.cs
+++ b/src/Machine/test/Serval.Machine.Shared.Tests/Services/EchoWordAlignmentEngineServiceTests.cs
@@ -56,7 +56,6 @@ public class EchoWordAlignmentEngineServiceTests
         Assert.That(await env.Service.CancelBuildAsync(EngineId1), Is.Null);
     }
 
-    [Test]
     public async Task DeleteAsync_WhileBuilding()
     {
         using var env = new TestEnvironment();

--- a/src/Serval/src/Serval.Shared.Contracts/ConflictException.cs
+++ b/src/Serval/src/Serval.Shared.Contracts/ConflictException.cs
@@ -1,0 +1,12 @@
+﻿namespace Serval.Shared.Contracts;
+
+public class ConflictException : Exception
+{
+    public ConflictException() { }
+
+    public ConflictException(string? message)
+        : base(message) { }
+
+    public ConflictException(string? message, Exception? innerException)
+        : base(message, innerException) { }
+}

--- a/src/Serval/src/Serval.Shared/Controllers/ConflictExceptionFilter.cs
+++ b/src/Serval/src/Serval.Shared/Controllers/ConflictExceptionFilter.cs
@@ -1,0 +1,13 @@
+﻿namespace Serval.Shared.Controllers;
+
+public class ConflictExceptionFilter : ExceptionFilterAttribute
+{
+    public override void OnException(ExceptionContext context)
+    {
+        if (context.Exception is ConflictException)
+        {
+            context.Result = new ConflictResult();
+            context.ExceptionHandled = true;
+        }
+    }
+}

--- a/src/Serval/src/Serval.Shared/Controllers/ServalControllerBase.cs
+++ b/src/Serval/src/Serval.Shared/Controllers/ServalControllerBase.cs
@@ -9,6 +9,7 @@
 [TypeFilter(typeof(NotFoundExceptionFilter))]
 [TypeFilter(typeof(ForbiddenExceptionFilter))]
 [TypeFilter(typeof(BadRequestExceptionFilter))]
+[TypeFilter(typeof(ConflictExceptionFilter))]
 public abstract class ServalControllerBase(IAuthorizationService authService) : Controller
 {
     private readonly IAuthorizationService _authService = authService;

--- a/src/Serval/src/Serval.Translation/Features/Engines/StartBuild.cs
+++ b/src/Serval/src/Serval.Translation/Features/Engines/StartBuild.cs
@@ -32,10 +32,7 @@ public record PretranslateCorpusConfigDto
 public record StartBuild(string Owner, string EngineId, TranslationBuildConfigDto BuildConfig)
     : IRequest<StartBuildResponse>;
 
-public record StartBuildResponse(
-    [property: MemberNotNullWhen(false, nameof(Build))] bool IsBuildRunning,
-    TranslationBuildDto? Build = null
-);
+public record StartBuildResponse(TranslationBuildDto Build);
 
 public class StartBuildHandler(
     IDataAccessContext dataAccessContext,
@@ -69,7 +66,7 @@ public class StartBuildHandler(
                     )
                 )
                 {
-                    return new StartBuildResponse(IsBuildRunning: true);
+                    throw new ConflictException();
                 }
 
                 Build build = new()
@@ -123,7 +120,7 @@ public class StartBuildHandler(
                 await engineFactory
                     .GetEngineService(engine.Type)
                     .StartBuildAsync(engine.Id, build.Id, corpora, buildOptions, ct);
-                return new StartBuildResponse(IsBuildRunning: false, Build: dtoMapper.Map(build));
+                return new StartBuildResponse(dtoMapper.Map(build));
             },
             cancellationToken
         );
@@ -436,10 +433,6 @@ public partial class TranslationEnginesController
     )
     {
         StartBuildResponse response = await handler.HandleAsync(new(Owner, id, buildConfig), cancellationToken);
-
-        if (response.IsBuildRunning)
-            return Conflict();
-
         return Created(response.Build.Url, response.Build);
     }
 }

--- a/src/Serval/src/Serval.WordAlignment/Features/Engines/StartBuild.cs
+++ b/src/Serval/src/Serval.WordAlignment/Features/Engines/StartBuild.cs
@@ -24,10 +24,7 @@ public record WordAlignmentCorpusConfigDto
 public record StartBuild(string Owner, string EngineId, WordAlignmentBuildConfigDto BuildConfig)
     : IRequest<StartBuildResponse>;
 
-public record StartBuildResponse(
-    [property: MemberNotNullWhen(false, nameof(Build))] bool IsBuildRunning,
-    WordAlignmentBuildDto? Build = null
-);
+public record StartBuildResponse(WordAlignmentBuildDto Build);
 
 public class StartBuildHandler(
     IDataAccessContext dataAccessContext,
@@ -61,7 +58,7 @@ public class StartBuildHandler(
                     )
                 )
                 {
-                    return new StartBuildResponse(IsBuildRunning: true);
+                    throw new ConflictException();
                 }
 
                 Build build = new()
@@ -113,7 +110,7 @@ public class StartBuildHandler(
                 await engineFactory
                     .GetEngineService(engine.Type)
                     .StartBuildAsync(engine.Id, build.Id, corpora, buildOptions, ct);
-                return new StartBuildResponse(IsBuildRunning: false, Build: dtoMapper.Map(build));
+                return new StartBuildResponse(dtoMapper.Map(build));
             },
             cancellationToken
         );
@@ -320,10 +317,6 @@ public partial class WordAlignmentEnginesController
     )
     {
         StartBuildResponse response = await handler.HandleAsync(new(Owner, id, buildConfig), cancellationToken);
-
-        if (response.IsBuildRunning)
-            return Conflict();
-
         return Created(response.Build.Url, response.Build);
     }
 }

--- a/src/Serval/test/Serval.Translation.Tests/Features/Engines/EnginesHandlersTests.cs
+++ b/src/Serval/test/Serval.Translation.Tests/Features/Engines/EnginesHandlersTests.cs
@@ -179,12 +179,11 @@ public class EnginesHandlersTests
         StartBuildResponse response = await handler.HandleAsync(
             new StartBuild(OWNER, engineId, new TranslationBuildConfigDto())
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -255,12 +254,11 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -333,12 +331,11 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -408,12 +405,11 @@ public class EnginesHandlersTests
                 new TranslationBuildConfigDto { TrainOn = [new TrainingCorpusConfigDto { CorpusId = "corpus1" }] }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -485,12 +481,11 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -562,12 +557,11 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -709,12 +703,11 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -787,12 +780,11 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -873,12 +865,11 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -990,12 +981,11 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -1077,12 +1067,11 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -1205,12 +1194,11 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -1335,12 +1323,11 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -1461,12 +1448,11 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -1622,12 +1608,11 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -1719,12 +1704,11 @@ public class EnginesHandlersTests
         StartBuildResponse response = await handler.HandleAsync(
             new StartBuild(OWNER, engineId, new TranslationBuildConfigDto())
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {
@@ -1833,12 +1817,11 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.IsBuildRunning, Is.False);
         await env
             .TranslationEngineService.Received()
             .StartBuildAsync(
                 engineId,
-                response.Build!.Id,
+                response.Build.Id,
                 ArgEx.IsEquivalentTo<IReadOnlyList<ParallelCorpusContract>>([
                     new()
                     {

--- a/src/Serval/test/Serval.WordAlignment.Tests/Features/Engines/EnginesHandlersTests.cs
+++ b/src/Serval/test/Serval.WordAlignment.Tests/Features/Engines/EnginesHandlersTests.cs
@@ -119,7 +119,6 @@ public class EnginesHandlersTests
             env.DtoMapper,
             Substitute.For<Microsoft.Extensions.Configuration.IConfiguration>()
         ).HandleAsync(new(OWNER, engineId, new()));
-        Assert.That(response.Build, Is.Not.Null);
         await env
             .WordAlignmentEngineService.Received()
             .StartBuildAsync(
@@ -202,7 +201,6 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.Build, Is.Not.Null);
         await env
             .WordAlignmentEngineService.Received()
             .StartBuildAsync(
@@ -287,7 +285,6 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.Build, Is.Not.Null);
         await env
             .WordAlignmentEngineService.Received()
             .StartBuildAsync(
@@ -372,7 +369,6 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.Build, Is.Not.Null);
         await env
             .WordAlignmentEngineService.Received()
             .StartBuildAsync(
@@ -448,7 +444,6 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.Build, Is.Not.Null);
         await env
             .WordAlignmentEngineService.Received()
             .StartBuildAsync(
@@ -524,7 +519,6 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.Build, Is.Not.Null);
         await env
             .WordAlignmentEngineService.Received()
             .StartBuildAsync(
@@ -701,7 +695,6 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.Build, Is.Not.Null);
         await env
             .WordAlignmentEngineService.Received()
             .StartBuildAsync(
@@ -786,7 +779,6 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.Build, Is.Not.Null);
         await env
             .WordAlignmentEngineService.Received()
             .StartBuildAsync(
@@ -879,7 +871,6 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.Build, Is.Not.Null);
         await env
             .WordAlignmentEngineService.Received()
             .StartBuildAsync(
@@ -1005,7 +996,6 @@ public class EnginesHandlersTests
                 }
             )
         );
-        Assert.That(response.Build, Is.Not.Null);
         await env
             .WordAlignmentEngineService.Received()
             .StartBuildAsync(


### PR DESCRIPTION
Fixes #944.

I was unsure what error to throw - I settled on a `DuplicateKeyException`, as technically the key "1 build per engine" has been violated, and I thought the filter would be helpful to filter these exceptions wherever they occur unhandled as a 409 HTTP status code.

An alternative would be to have a `ConflictException` class, although this could really only go in Serval.Shared.Contracts or SIL.DataAccess.Abstractions. Let me know if you would prefer this approach, and if so, where you would want the exception class to sit (neither option stands out to me as being ideal).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/1006)
<!-- Reviewable:end -->
