### PR TITLE
Fix typo in E2E test

### DIFF
--- a/src/Serval/test/Serval.E2ETests/ServalApiTests.cs
+++ b/src/Serval/test/Serval.E2ETests/ServalApiTests.cs
@@ -261,8 +261,8 @@ public class ServalApiTests
         {
             ParallelCorpusConfig textCorpus = await _helperClient.MakeParallelTextCorpus(
                 ["1JN.txt"],
-                "es",
-                "en",
+                SourceLanguageCode,
+                TargetLanguageCode,
                 false
             );
             string textCorpusId = await _helperClient.AddParallelTextCorpusToEngineAsync(engineId, textCorpus, false);


### PR DESCRIPTION
We were using data in different languages unintentionally. Doesn't really matter since we aren't testing the quality of the translations but worth changing for consistency.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/1007)
<!-- Reviewable:end -->
