### PR TITLE
Fix filename -> fileName in diagnostic data keys

### DIFF
--- a/src/Machine/src/Serval.Machine.Shared/Services/PreprocessBuildJob.cs
+++ b/src/Machine/src/Serval.Machine.Shared/Services/PreprocessBuildJob.cs
@@ -165,7 +165,7 @@ public abstract class PreprocessBuildJob<TEngine>(
                                 {
                                     { "projectName", projectName },
                                     { "projectGuid", projectGuid },
-                                    { "usfmFilename", usfmDiagnostic.Filename },
+                                    { "usfmFileName", usfmDiagnostic.Filename },
                                     {
                                         "lineNumber",
                                         usfmDiagnostic.LineNumbers.Count > 0 ? usfmDiagnostic.LineNumbers[0] : -1
@@ -185,7 +185,7 @@ public abstract class PreprocessBuildJob<TEngine>(
                                 {
                                     { "projectName", projectName },
                                     { "projectGuid", projectGuid },
-                                    { "usfmFilename", usfmDiagnostic.Filename },
+                                    { "usfmFileName", usfmDiagnostic.Filename },
                                     {
                                         "lineNumber",
                                         usfmDiagnostic.LineNumbers.Count > 0 ? usfmDiagnostic.LineNumbers[0] : -1
@@ -207,7 +207,7 @@ public abstract class PreprocessBuildJob<TEngine>(
                                     { "numberOfVerses", usfmDiagnostic.NumAffectedVerses },
                                     { "projectName", projectName },
                                     { "projectGuid", projectGuid },
-                                    { "usfmFilename", usfmDiagnostic.Filename },
+                                    { "usfmFileName", usfmDiagnostic.Filename },
                                     { "lineNumbers", usfmDiagnostic.LineNumbers.ToList() },
                                     { "verseReferences", usfmDiagnostic.References.ToList() },
                                     { "parallelCorpusId", parallelCorpusId },
@@ -222,7 +222,7 @@ public abstract class PreprocessBuildJob<TEngine>(
                                     { "numberOfVerses", usfmDiagnostic.NumAffectedVerses },
                                     { "projectName", projectName },
                                     { "projectGuid", projectGuid },
-                                    { "usfmFilename", usfmDiagnostic.Filename },
+                                    { "usfmFileName", usfmDiagnostic.Filename },
                                     { "lineNumbers", usfmDiagnostic.LineNumbers.ToList() },
                                     { "verseReferences", usfmDiagnostic.References.ToList() },
                                     { "parallelCorpusId", parallelCorpusId },
@@ -236,7 +236,7 @@ public abstract class PreprocessBuildJob<TEngine>(
                                 {
                                     { "projectName", projectName },
                                     { "projectGuid", projectGuid },
-                                    { "usfmFilename", usfmDiagnostic.Filename },
+                                    { "usfmFileName", usfmDiagnostic.Filename },
                                     {
                                         "lineNumber",
                                         usfmDiagnostic.LineNumbers.Count > 0 ? usfmDiagnostic.LineNumbers[0] : -1
@@ -256,7 +256,7 @@ public abstract class PreprocessBuildJob<TEngine>(
                                 {
                                     { "projectName", projectName },
                                     { "projectGuid", projectGuid },
-                                    { "usfmFilename", usfmDiagnostic.Filename },
+                                    { "usfmFileName", usfmDiagnostic.Filename },
                                     {
                                         "lineNumber",
                                         usfmDiagnostic.LineNumbers.Count > 0 ? usfmDiagnostic.LineNumbers[0] : -1

--- a/src/Machine/test/Serval.Machine.Translation.Tests/Services/PreprocessBuildJobTests.cs
+++ b/src/Machine/test/Serval.Machine.Translation.Tests/Services/PreprocessBuildJobTests.cs
@@ -166,7 +166,7 @@ public class PreprocessBuildJobTests
             Assert.That(data["numberOfVerses"] is int numberOfVerses && numberOfVerses == 2);
             Assert.That(data["projectName"] is string projectName && projectName == "pt-source1");
             Assert.That(data["projectGuid"] is string projectGuid && projectGuid == "0000");
-            Assert.That(data["usfmFilename"] is string usfmFilename && usfmFilename == "41MAT.SFM");
+            Assert.That(data["usfmFileName"] is string usfmFileName && usfmFileName == "41MAT.SFM");
             Assert.That(data["lineNumbers"] is List<int> lineNumbers && lineNumbers.SequenceEqual([4, 5]));
             Assert.That(
                 data["verseReferences"] is List<string> verseReferences
@@ -184,7 +184,7 @@ public class PreprocessBuildJobTests
             Assert.That(data["numberOfVerses"] is int numberOfVerses && numberOfVerses == 1);
             Assert.That(data["projectName"] is string projectName && projectName == "pt-source1");
             Assert.That(data["projectGuid"] is string projectGuid && projectGuid == "0000");
-            Assert.That(data["usfmFilename"] is string usfmFilename && usfmFilename == "41MAT.SFM");
+            Assert.That(data["usfmFileName"] is string usfmFileName && usfmFileName == "41MAT.SFM");
             Assert.That(data["lineNumbers"] is List<int> lineNumbers && lineNumbers.SequenceEqual([3]));
             Assert.That(
                 data["verseReferences"] is List<string> verseReferences && verseReferences.SequenceEqual(["MAT 1:1"])
@@ -200,7 +200,7 @@ public class PreprocessBuildJobTests
         {
             Assert.That(data["projectName"] is string projectName && projectName == "pt-target1");
             Assert.That(data["projectGuid"] is string projectGuid && projectGuid == "1111");
-            Assert.That(data["usfmFilename"] is string usfmFilename && usfmFilename == "41MAT.SFM");
+            Assert.That(data["usfmFileName"] is string usfmFileName && usfmFileName == "41MAT.SFM");
             Assert.That(data["lineNumber"] is int lineNumber && lineNumber == 6);
             Assert.That(data["verseReference"] is string verseReference && verseReference == "MAT 1:4a");
             Assert.That(data["parallelCorpusId"] is string parallelCorpusId && parallelCorpusId == "corpusId1");
@@ -214,7 +214,7 @@ public class PreprocessBuildJobTests
         {
             Assert.That(data["projectName"] is string projectName && projectName == "pt-target1");
             Assert.That(data["projectGuid"] is string projectGuid && projectGuid == "1111");
-            Assert.That(data["usfmFilename"] is string usfmFilename && usfmFilename == "41MAT.SFM");
+            Assert.That(data["usfmFileName"] is string usfmFileName && usfmFileName == "41MAT.SFM");
             Assert.That(data["lineNumber"] is int lineNumber && lineNumber == 12);
             Assert.That(data["verseReference"] is string verseReference && verseReference == "MAT :1");
             Assert.That(data["parallelCorpusId"] is string parallelCorpusId && parallelCorpusId == "corpusId1");
@@ -228,7 +228,7 @@ public class PreprocessBuildJobTests
         {
             Assert.That(data["projectName"] is string projectName && projectName == "pt-target1");
             Assert.That(data["projectGuid"] is string projectGuid && projectGuid == "1111");
-            Assert.That(data["usfmFilename"] is string usfmFilename && usfmFilename == "41MAT.SFM");
+            Assert.That(data["usfmFileName"] is string usfmFileName && usfmFileName == "41MAT.SFM");
             Assert.That(data["lineNumber"] is int lineNumber && lineNumber == 13);
             Assert.That(data["verseReference"] is string verseReference && verseReference == "MAT 2:1$");
             Assert.That(data["parallelCorpusId"] is string parallelCorpusId && parallelCorpusId == "corpusId1");
@@ -242,7 +242,7 @@ public class PreprocessBuildJobTests
         {
             Assert.That(data["projectName"] is string projectName && projectName == "pt-target1");
             Assert.That(data["projectGuid"] is string projectGuid && projectGuid == "1111");
-            Assert.That(data["usfmFilename"] is string usfmFilename && usfmFilename == "41MAT.SFM");
+            Assert.That(data["usfmFileName"] is string usfmFileName && usfmFileName == "41MAT.SFM");
             Assert.That(data["lineNumber"] is int lineNumber && lineNumber == 20);
             Assert.That(data["verseReference"] is string verseReference && verseReference == "MAT 2:2-16");
             Assert.That(data["parallelCorpusId"] is string parallelCorpusId && parallelCorpusId == "corpusId1");


### PR DESCRIPTION
Fixes a misspelling which is causing a failing E2E test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/serval/1024)
<!-- Reviewable:end -->
